### PR TITLE
Catch error when testcase is corrupted

### DIFF
--- a/grizzly/reduce/reduce.py
+++ b/grizzly/reduce/reduce.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import tempfile
 import zipfile
+import zlib
 
 import lithium
 from FTB.Signatures.CrashInfo import CrashSignature
@@ -200,8 +201,11 @@ class ReductionJob(object):
                     info_fp.write("landing page: %s\n" % (os.path.basename(testcase),))
             elif testcase.lower().endswith(".zip"):
                 os.mkdir(self.tcroot)
-                with zipfile.ZipFile(testcase) as zip_fp:
-                    zip_fp.extractall(path=self.tcroot)
+                try:
+                    with zipfile.ZipFile(testcase) as zip_fp:
+                        zip_fp.extractall(path=self.tcroot)
+                except zlib.error:
+                    raise ReducerError("Testcase is corrupted")
             else:
                 raise ReducerError("Testcase must be zip, html, or directory")
         elif os.path.isdir(testcase):


### PR DESCRIPTION
Reduce raises an unhandled exception when the testcase is corrupted.
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/user/tools/grizzly/grizzly/reduce/bucket.py", line 135, in <module>
    sys.exit(main(ReducerFuzzManagerIDArgs().parse_args()))
  File "/home/user/tools/grizzly/grizzly/reduce/bucket.py", line 121, in main
    if reduce_crash(args) == 0:
  File "/home/user/tools/grizzly/grizzly/reduce/crash.py", line 140, in main
    return reduce_main(args, interesting_cb=_on_interesting, result_cb=_on_result)
  File "/home/user/tools/grizzly/grizzly/reduce/reduce.py", line 643, in main
    job.config_testcase(args.input)
  File "/home/user/tools/grizzly/grizzly/reduce/reduce.py", line 204, in config_testcase
    zip_fp.extractall(path=self.tcroot)
  File "/usr/lib/python2.7/zipfile.py", line 1040, in extractall
    self.extract(zipinfo, path, pwd)
  File "/usr/lib/python2.7/zipfile.py", line 1028, in extract
    return self._extract_member(member, path, pwd)
  File "/usr/lib/python2.7/zipfile.py", line 1084, in _extract_member
    shutil.copyfileobj(source, target)
  File "/usr/lib/python2.7/shutil.py", line 63, in copyfileobj
    buf = fsrc.read(length)
  File "/usr/lib/python2.7/zipfile.py", line 632, in read
    data = self.read1(n - len(buf))
  File "/usr/lib/python2.7/zipfile.py", line 684, in read1
    max(n - len_readbuffer, self.MIN_READ_SIZE)
zlib.error: Error -3 while decompressing: invalid distance code
```