### PR TITLE
Use unload instead of beforeunload

### DIFF
--- a/grizzly/corpman/harness.html
+++ b/grizzly/corpman/harness.html
@@ -32,10 +32,12 @@ function main() {
     return
   }
 
-  sub.addEventListener('unload', function () {
-    clearTimeout(limit_tmr)
-    grzDump('Test case closed')
-    setTimeout(main, 0)
+  sub.addEventListener('unload', (evt) => {
+    if (evt.target.location.href !== 'about:blank') {
+      clearTimeout(limit_tmr)
+      grzDump('Test case closed')
+      setTimeout(main, 0)
+    }
   })
 
   limit_tmr = setTimeout(() => {


### PR DESCRIPTION
Testcases that call document.write appear to destroy the document which prevents beforeunload from firing.  This PR uses the unload event instead and captures the current requested URL via DOMContentLoaded.