### PR TITLE
[reducer] Improve update timeout logic

### DIFF
--- a/grizzly/reduce/interesting.py
+++ b/grizzly/reduce/interesting.py
@@ -299,14 +299,9 @@ class Interesting(object):
 
         # launch sapphire if needed
         if self.server is None:
-            if self.no_harness:
-                serve_timeout = self.iter_timeout
-            else:
-                # wait a few extra seconds to avoid races between the harness & sapphire timing out
-                serve_timeout = self.iter_timeout + 10
             # have client error pages (code 4XX) call window.close() after a few seconds
             sapphire.Sapphire.CLOSE_CLIENT_ERROR = 2
-            self.server = sapphire.Sapphire(timeout=serve_timeout)
+            self.server = sapphire.Sapphire()
 
             if not self.no_harness:
                 harness = os.path.join(os.path.dirname(__file__), '..', 'common', 'harness.html')
@@ -319,6 +314,12 @@ class Interesting(object):
                 self.server.add_dynamic_response("/close_browser", _dyn_resp_close, mime_type="text/html")
                 self.server.add_dynamic_response("/harness", lambda: harness, mime_type="text/html")
                 self.server.set_redirect("/first_test", str(self.landing_page), required=True)
+
+        if self.no_harness:
+            self.server.timeout = self.iter_timeout
+        else:
+            # wait a few extra seconds to avoid races between the harness & sapphire timing out
+            self.server.timeout = self.iter_timeout + 10
 
         # (re)launch Target
         if self.target.closed:

--- a/grizzly/reduce/test_interesting.py
+++ b/grizzly/reduce/test_interesting.py
@@ -70,7 +70,6 @@ def test_interesting(tmp_path):
     obj.init(None)
     (tmp_path / "lithium").mkdir()
     assert obj.interesting(None, str(tmp_path / "lithium"))
-    assert obj.server is None
     assert obj.target._calls["close"] == 1
     obj.cleanup(None)
     assert obj.target._calls["cleanup"] == 0
@@ -160,7 +159,6 @@ def test_no_harness(tmp_path):
     obj.reduce_file = str(reduce_file)
     obj.init(None)
     assert obj.interesting(None, str(prefix))
-    assert obj.server is None
     assert obj.target._calls["close"] == 1
     obj.cleanup(None)
     assert obj.target._calls["cleanup"] == 0
@@ -181,7 +179,6 @@ def test_skip(tmp_path):
     assert obj.interesting(None, str(prefix))
     assert obj.target._calls["launch"] == 1
     assert obj.target._calls["close"] == 1
-    assert obj.server is None
     for _ in range(7):
         assert not obj.interesting(None, None)
     assert obj.target._calls["launch"] == 1
@@ -218,7 +215,6 @@ def test_any_crash_false(tmp_path):
     assert obj.interesting(None, str(prefix))
     assert obj.target._calls["launch"] == 1
     assert obj.target._calls["close"] == 1
-    assert obj.server is None
     prefix = tmp_path / "lithium1"
     prefix.mkdir()
     stderr = "Assertion failure: some other thing happened, at test.c:456"
@@ -253,7 +249,6 @@ def test_any_crash_true(tmp_path):
     assert obj.interesting(None, str(prefix))
     assert obj.target._calls["launch"] == 1
     assert obj.target._calls["close"] == 1
-    assert obj.server is None
     prefix = tmp_path / "lithium1"
     prefix.mkdir()
     stderr = "Assertion failure: some other thing happened, at test.c:456"
@@ -413,7 +408,6 @@ def test_timeout_update(monkeypatch, tmp_path):
     assert obj.interesting(None, tmp_path / "lithium1")
     assert obj.idle_timeout < 30
     idle_timeout = obj.idle_timeout
-    assert obj.server is None  # killed to update timeout
     assert FakeServer._last_timeout == last_timeout
     last_timeout = FakeServer._last_timeout
     (tmp_path / "lithium2").mkdir()

--- a/grizzly/reduce/test_interesting.py
+++ b/grizzly/reduce/test_interesting.py
@@ -37,6 +37,15 @@ class FakeServer(object):
     def serve_path(self, *args, **kwds):
         return sapphire.SERVED_ALL, []
 
+    @property
+    def timeout(self):
+        return FakeServer._last_timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        assert value is None or value >= 0
+        FakeServer._last_timeout = value
+
 
 @pytest.fixture
 def fake_sapphire(monkeypatch):

--- a/grizzly/reduce/test_reduce.py
+++ b/grizzly/reduce/test_reduce.py
@@ -27,7 +27,7 @@ class FakeInteresting(interesting.Interesting):
         os.mkdir(result_logs)
         self.target.save_logs(result_logs, meta=True)
         with open(self.reduce_file) as fp:
-            return "required" in fp.read()
+            return 0.1 if "required" in fp.read() else -1
 
     def cleanup(self, _):
         pass
@@ -48,8 +48,8 @@ class FakeInterestingAlt(FakeInteresting):
                 self.alt_crash_cb(testcase, temp_prefix)
         if self.__first_run:
             self.__first_run = False
-            return True
-        return False
+            return 0.1
+        return -1
 
 
 class FakeInterestingKeepHarness(FakeInteresting):
@@ -67,10 +67,10 @@ class FakeInterestingKeepHarness(FakeInteresting):
         self.target.save_logs(result_logs, meta=True)
         if self.__init_data is not None:
             with open(self.reduce_file) as fp:
-                return self.__init_data == fp.read()
+                return 1 if self.__init_data == fp.read() else -1
         else:
             with open(self.reduce_file) as fp:
-                return "required" in fp.read()
+                return 1 if "required" in fp.read() else -1
 
 
 class FakeInterestingSemiReliable(FakeInteresting):
@@ -87,9 +87,9 @@ class FakeInterestingSemiReliable(FakeInteresting):
         os.mkdir(result_logs)
         self.target.save_logs(result_logs, meta=True)
         if self.require_no_harness and "harness" in self.location:
-            return False
+            return -1
         self.interesting_count += 1
-        return self.interesting_count <= self.interesting_times
+        return 1 if self.interesting_count <= self.interesting_times else -1
 
 
 class FakeInterestingSemiReliableWithCache(FakeInterestingSemiReliable):

--- a/sapphire/test_sapphire.py
+++ b/sapphire/test_sapphire.py
@@ -49,6 +49,7 @@ def test_sapphire_00(client, tmp_path):
     """test requesting a single test case file"""
     serv = Sapphire(timeout=10)
     try:
+        assert serv.timeout == 10
         test = _create_test("test_case.html", tmp_path)
         client.launch("127.0.0.1", serv.get_port(), [test])
         assert serv.serve_path(str(tmp_path))[0] == SERVED_ALL
@@ -177,8 +178,15 @@ def test_sapphire_05(client, tmp_path):
 
 def test_sapphire_06(tmp_path):
     """test timeout of the server"""
-    serv = Sapphire(timeout=1)  # minimum timeout is 1 second
+    serv = Sapphire(timeout=60)
     try:
+        assert serv.timeout == 60  # verify default
+        serv.timeout = None  # disable timeout
+        assert serv.timeout == 0
+        serv.timeout = 0  # disable timeout
+        assert serv.timeout == 0
+        serv.timeout = 0.1  # set minimum time
+        assert serv.timeout == 1
         _create_test("test_case.html", tmp_path)
         status, files_served = serv.serve_path(str(tmp_path))
     finally:


### PR DESCRIPTION
Only attempt to update timeout when a chuck was removed and use longest successful iteration duration when doing so. This will help reduce test cases that have an inconsistent time to reproduce.
