### PR TITLE
Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
   include:
     - os: osx
       python: 2.7
-      language: generic
+      language: shell
     - os: osx
       python: 3.7
-      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
-      language: shell       # 'language: python' is an error on Travis CI macOS
+      osx_image: xcode11.2
+      language: shell
     - os: windows
       python: 2.7
       language: shell
@@ -29,14 +29,17 @@ matrix:
       before_install:
         - choco install python --version 3.8.0
       env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+  allow_failures:
+    - os: osx # temporary disable while image is broken
+      python: 3.7
 before_install:
   - pip install --upgrade setuptools pip
 install:
-  - python -m pip install -e .[all]
+  - pip install -e .[all]
 before_script:
   - pip install --upgrade pytest pytest-mock pytest-pylint pytest-cov codecov
 script:
-  - python -m pytest
+  - pytest
 after_success:
   - codecov
 deploy:


### PR DESCRIPTION
Temporarily allow failures on MacOS running Python 3 since the image seems to be broken.