### PR TITLE
[replay] Add '--test-index' argument

### DIFF
--- a/grizzly/replay/args.py
+++ b/grizzly/replay/args.py
@@ -48,6 +48,11 @@ class ReplayArgs(CommonArgs):
         replay_args.add_argument(
             "--sig",
             help="Signature (JSON) file to match.")
+        replay_args.add_argument(
+            "--test-index", type=int,
+            help="Select a testcase to run when multiple testcases are loaded. " \
+                 "Testscases are ordered oldest to newest. Indexing is 0 based. " \
+                 "0 == Oldest, -1 == Newest (default: run all testcases)")
 
         self.launcher_grp.add_argument(
             "--rr", action="store_true",


### PR DESCRIPTION
Here is an alternate solution to the `--no-harness` multi-part test case problem. Personally I'd prefer this. It will mean more logic in the reducer but I think that is where it belongs.