### PR TITLE
Add back grizzly.reduce.crash and grizzly.reduce.bucket

### DIFF
--- a/grizzly/common/fuzzmanager.py
+++ b/grizzly/common/fuzzmanager.py
@@ -1,0 +1,261 @@
+# coding=utf-8
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Interface for getting Crash and Bucket data from CrashManager API"""
+import json
+from logging import getLogger
+from os import unlink
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp, mkstemp
+
+from Collector.Collector import Collector
+
+
+LOG = getLogger(__name__)
+
+
+class Bucket(object):
+    """Get Bucket data for a specified CrashManager bucket."""
+
+    def __init__(self, bucket_id):
+        """Initialize a Bucket instance.
+
+        Arguments:
+            bucket_id (int): ID of the requested bucket on the server side
+        """
+        self._bucket_id = bucket_id
+        self._sig_filename = None
+        self._coll = Collector()
+        self._url = "%s://%s:%d/crashmanager/rest/buckets/%d/" % (
+            self._coll.serverProtocol,
+            self._coll.serverHost,
+            self._coll.serverPort,
+            bucket_id,
+        )
+        self._data = None
+
+    @property
+    def bucket_id(self):
+        return self._bucket_id
+
+    def __getattr__(self, name):
+        if self._data is None:
+            self._data = self._coll.get(self._url).json()
+        if name not in self._data:
+            raise AttributeError(
+                "'%s' object has no attribute '%s' (has: %s)"
+                % (type(self).__name__, name, list(self._data))
+            )
+        return self._data[name]
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+            return
+        raise AttributeError("can't set attribute")
+
+    def cleanup(self):
+        """Cleanup any resources held by this instance.
+
+        Arguments:
+            None
+
+        Returns:
+            None
+        """
+        if self._sig_filename is not None:
+            rmtree(str(self._sig_filename.parent))
+
+    def iter_crashes(self, quality_filter=None):
+        """Fetch all crash IDs for this FuzzManager bucket.
+        Only crashes with testcases are returned.
+
+        Arguments:
+            quality_filter (int): Filter crashes by quality value (None for all)
+
+        Returns:
+            generator: generator of CrashEntry
+        """
+
+        def _get_results(endpoint, params=None):
+            """
+            Function to get paginated results from FuzzManager
+
+            Args:
+                endpoint (str): FuzzManager REST API to query (eg. "crashes").
+                params (dict): Params to pass through to requests.get
+
+            Returns:
+                generator: objects returned by FuzzManager (as dicts)
+            """
+            LOG.debug("first request to /%s/", endpoint)
+
+            url = "%s://%s:%d/crashmanager/rest/%s/" \
+                % (self._coll.serverProtocol, self._coll.serverHost,
+                   self._coll.serverPort, endpoint)
+
+            response = self._coll.get(url, params=params).json()
+
+            while True:
+                LOG.debug("got %d/%d %s", len(response["results"]), response["count"], endpoint)
+                while response["results"]:
+                    yield response["results"].pop()
+
+                if response["next"] is None:
+                    break
+
+                LOG.debug("next request to /%s/", endpoint)
+                response = self._coll.get(response["next"]).json()
+
+        # Get all crashes for bucket
+        query_args = [
+            ("op", "AND"),
+            ("bucket", self.bucket_id),
+        ]
+        if quality_filter is not None:
+            query_args.append(("testcase__quality", quality_filter))
+        query = json.dumps(dict(query_args))
+
+        n_yielded = 0
+        for crash in _get_results("crashes", params={"query": query, "include_raw": "0"}):
+
+            if not crash["testcase"]:
+                LOG.warning("crash %d has no testcase, skipping", crash["id"])
+                continue
+
+            n_yielded += 1
+            LOG.debug("yielding crash #%d", n_yielded)
+            result = CrashEntry(crash["id"])
+            result._data = crash  # pylint: disable=protected-access
+            yield result
+
+    def signature_path(self):
+        """Download the bucket data from CrashManager.
+
+        Arguments:
+            None
+
+        Returns:
+            Path: Path on disk where signature exists.
+        """
+        if self._sig_filename is not None:
+            return self._sig_filename
+
+        tmpd = Path(mkdtemp(prefix="grizzly-reduce-"))
+        try:
+            sig_basename = "%d.signature" % (self._bucket_id,)
+            sig_filename = tmpd / sig_basename
+            sig_filename.write_text(self.signature)
+            sigmeta_filename = sig_filename.with_suffix(".metadata")
+            sigmeta_filename.write_text(
+                json.dumps(
+                    {
+                        "size": self.size,
+                        "frequent": self.frequent,
+                        "shortDescription": self.shortDescription,
+                        "testcase__quality": self.best_quality,
+                    }
+                )
+            )
+        except:  # noqa pragma: no cover pylint: disable=bare-except
+            rmtree(str(tmpd))
+            raise
+
+        self._sig_filename = sig_filename
+        return self._sig_filename
+
+
+class CrashEntry(object):
+    """Get the CrashEntry data for the specified CrashManager crash.
+
+    Attributes:
+        crash_id (int): the server ID for the crash
+        see crashmanager.serializers.CrashEntrySerializer
+    """
+    RAW_FIELDS = frozenset({"rawCrashData", "rawStderr", "rawStdout"})
+
+    def __init__(self, crash_id):
+        """Initialize CrashEntry.
+
+        Arguments:
+            crash_id (int): ID of the requested crash on the server side
+        """
+        self._crash_id = crash_id
+        self._coll = Collector()
+        self._url = "%s://%s:%d/crashmanager/rest/crashes/%d/" % (
+            self._coll.serverProtocol,
+            self._coll.serverHost,
+            self._coll.serverPort,
+            crash_id,
+        )
+        self._data = None
+        self._tc_filename = None
+
+    @property
+    def crash_id(self):
+        return self._crash_id
+
+    def __getattr__(self, name):
+        if self._data is None or (name in self.RAW_FIELDS and name not in self._data):
+            need_raw = "1" if name in self.RAW_FIELDS else "0"
+            self._data = self._coll.get(self._url, params={"include_raw": need_raw}).json()
+        if name not in self._data:
+            raise AttributeError(
+                "'%s' object has no attribute '%s' (has: %s)"
+                % (type(self).__name__, name, list(self._data))
+            )
+        return self._data[name]
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+            return
+        if name != "testcase_quality":
+            raise AttributeError("can't set attribute")
+        self._coll.patch(self._url, data={name: value})
+        if self._data:
+            self._data[name] = value
+
+    def cleanup(self):
+        """Cleanup any resources held by this instance.
+
+        Arguments:
+            None
+
+        Returns:
+            None
+        """
+        if self._tc_filename is not None:
+            self._tc_filename.unlink()
+
+    def testcase_path(self):
+        """Download the testcase data from CrashManager.
+
+        Arguments:
+            None
+
+        Returns:
+            Path: Path on disk where testcase exists_
+        """
+        if self._tc_filename is not None:
+            return self._tc_filename
+
+        dlurl = self._url + "download/"
+        response = self._coll.get(dlurl)
+
+        if "content-disposition" not in response.headers:
+            raise RuntimeError("Server sent malformed response: %r" % (response,))  # pragma: no cover
+
+        handle, filename = mkstemp(
+            prefix="grizzly-reduce-%d-" % (self.crash_id,), suffix=Path(self.testcase).suffix
+        )
+        try:
+            with open(handle, "wb") as output:
+                output.write(response.content)
+        except:  # noqa pragma: no cover pylint: disable=bare-except
+            unlink(filename)
+            raise
+        self._tc_filename = Path(filename)
+        return self._tc_filename

--- a/grizzly/common/fuzzmanager.py
+++ b/grizzly/common/fuzzmanager.py
@@ -12,6 +12,8 @@ from tempfile import mkdtemp, mkstemp
 
 from Collector.Collector import Collector
 
+from .utils import grz_tmp
+
 
 LOG = getLogger(__name__)
 
@@ -143,7 +145,8 @@ class Bucket(object):
         if self._sig_filename is not None:
             return self._sig_filename
 
-        tmpd = Path(mkdtemp(prefix="grizzly-reduce-"))
+        tmpd = Path(mkdtemp(prefix="bucket-%d-" % (self._bucket_id,),
+                            dir=grz_tmp("fuzzmanager")))
         try:
             sig_basename = "%d.signature" % (self._bucket_id,)
             sig_filename = tmpd / sig_basename
@@ -248,8 +251,8 @@ class CrashEntry(object):
         if "content-disposition" not in response.headers:
             raise RuntimeError("Server sent malformed response: %r" % (response,))  # pragma: no cover
 
-        handle, filename = mkstemp(
-            prefix="grizzly-reduce-%d-" % (self.crash_id,), suffix=Path(self.testcase).suffix
+        handle, filename = mkstemp(dir=grz_tmp("fuzzmanager"),
+            prefix="crash-%d-" % (self.crash_id,), suffix=Path(self.testcase).suffix
         )
         try:
             with open(handle, "wb") as output:

--- a/grizzly/common/test_fuzzmanager.py
+++ b/grizzly/common/test_fuzzmanager.py
@@ -1,0 +1,191 @@
+# coding=utf-8
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Tests for interface for getting Crash and Bucket data from CrashManager API"""
+import json
+
+from pytest import raises
+
+from .fuzzmanager import Bucket, CrashEntry
+
+
+def test_bucket_1(mocker):
+    """bucket getattr uses data from get"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.get.return_value.json.return_value = {"testcase": "data"}
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    bucket = Bucket(123)
+    assert coll.return_value.get.call_count == 0
+    assert bucket.testcase == "data"
+    with raises(AttributeError):
+        getattr(bucket, "other")
+    assert coll.return_value.get.call_count == 1
+
+
+def test_bucket_2(mocker):
+    """bucket setattr raises"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    bucket = Bucket(123)
+    with raises(AttributeError):
+        bucket.other = "data"
+    assert coll.return_value.get.call_count == 0
+
+
+def test_bucket_3(mocker):
+    """bucket iter_crashes flattens across pages"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    coll.return_value.get.return_value.json.side_effect = [
+        {
+            "count": 2,
+            "next": "url",
+            "results": [
+                {"id": 234, "testcase": "test1"},
+                {"id": 345, "testcase": None},
+            ],
+        },
+        {
+            "count": 1,
+            "next": None,
+            "results": [
+                {"id": 456, "testcase": "test2"},
+            ],
+        },
+    ]
+    bucket = Bucket(123)
+    assert coll.return_value.get.call_count == 0
+    crashes = list(bucket.iter_crashes(quality_filter=5))
+    assert coll.return_value.get.call_count == 2
+    assert coll.return_value.get.call_args_list[0][1]["params"]["include_raw"] == "0"
+    assert json.loads(coll.return_value.get.call_args_list[0][1]["params"]["query"]) == {
+        "op": "AND",
+        "bucket": 123,
+        "testcase__quality": 5,
+    }
+    assert len(crashes) == 2
+    assert crashes[0].crash_id == 234
+    assert crashes[1].crash_id == 456
+
+
+def test_bucket_4(mocker):
+    """bucket signature_path writes and returns sig json and metadata"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    coll.return_value.get.return_value.json.return_value = {
+        "signature": "sigdata",
+        "size": 10,
+        "frequent": True,
+        "shortDescription": "sig desc",
+        "best_quality": 0,
+    }
+    bucket = Bucket(123)
+    try:
+        assert coll.return_value.get.call_count == 0
+        sig_path = bucket.signature_path()
+        assert sig_path.is_file()
+        assert sig_path.with_suffix(".metadata").is_file()
+        assert sig_path.read_text() == "sigdata"
+        assert json.loads(sig_path.with_suffix(".metadata").read_text()) == {
+                        "size": 10,
+                        "frequent": True,
+                        "shortDescription": "sig desc",
+                        "testcase__quality": 0,
+        }
+        assert coll.return_value.get.call_count == 1
+        # second call returns same path
+        assert bucket.signature_path() == sig_path
+    finally:
+        bucket.cleanup()
+    assert coll.return_value.get.call_count == 1
+
+
+def test_crash_1(mocker):
+    """crash getattr uses data from get"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.get.return_value.json.return_value = {"testcase": "data"}
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    crash = CrashEntry(123)
+    assert coll.return_value.get.call_count == 0
+    assert crash.testcase == "data"
+    with raises(AttributeError):
+        getattr(crash, "other")
+    assert coll.return_value.get.call_count == 1
+    assert coll.return_value.get.call_args[1]["params"] == {"include_raw": "0"}
+
+    # crash getattr for raw field re-gets
+    coll.return_value.get.return_value.json.return_value = {"rawStderr": "stderr"}
+    assert crash.rawStderr == "stderr"
+    assert coll.return_value.get.call_count == 2
+    assert coll.return_value.get.call_args[1]["params"] == {"include_raw": "1"}
+
+
+def test_crash_2(mocker):
+    """crash setattr raises except testcase_quality"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.get.return_value.json.return_value = {"testcase": "data"}
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    crash = CrashEntry(123)
+
+    # crash setattr raises for other field
+    with raises(AttributeError):
+        crash.other = "data"
+    assert coll.return_value.get.call_count == 0
+
+    # crash setattr for testcase_quality works and updates data if set
+    assert coll.return_value.patch.call_count == 0
+    crash.testcase_quality = 5
+    assert coll.return_value.get.call_count == 0
+    assert coll.return_value.patch.call_count == 1
+    with raises(AttributeError):
+        getattr(crash, "testcase_quality")
+    assert coll.return_value.get.call_count == 1
+    getattr(crash, "testcase")
+    assert coll.return_value.get.call_count == 1
+    crash.testcase_quality = 10
+    assert coll.return_value.patch.call_count == 2
+    assert crash.testcase_quality == 10
+    assert coll.return_value.get.call_count == 1
+
+
+def test_crash_3(mocker):
+    """crash testcase_path writes and returns testcase zip"""
+    coll = mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    coll.return_value.serverProtocol = "http"
+    coll.return_value.serverPort = 123
+    coll.return_value.serverHost = "allizom.org"
+    coll.return_value.get.return_value.json.return_value = {
+        "id": 234,
+        "testcase": "test.bz2",
+    }
+    crash = CrashEntry(234)
+    assert crash.testcase == "test.bz2"  # pre-load data dict so I can re-patch get
+    coll.return_value.get.return_value = mocker.Mock(
+        content=b"\x01\x02\x03",
+        headers={"content-disposition"},
+    )
+    try:
+        assert coll.return_value.get.call_count == 1
+        tc_path = crash.testcase_path()
+        assert tc_path.is_file()
+        assert tc_path.suffix == ".bz2"
+        assert tc_path.read_bytes() == b"\x01\x02\x03"
+        assert coll.return_value.get.call_count == 2
+        # second call returns same path
+        assert crash.testcase_path() == tc_path
+    finally:
+        crash.cleanup()
+    assert coll.return_value.get.call_count == 2

--- a/grizzly/reduce/bucket.py
+++ b/grizzly/reduce/bucket.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from logging import getLogger
+import sys
+
+from .args import ReduceFuzzManagerIDQualityArgs
+from .crash import CrashEntry, main as crash_main
+from ..main import configure_logging
+from ..session import Session
+
+
+LOG = getLogger(__name__)
+
+
+def main(args):
+    """CLI for `grizzly.reduce.bucket`.
+
+    Arguments:
+        args (argparse.Namespace): Result from `ReduceArgs.parse_args`.
+
+    Returns:
+        int: 0 for success. non-0 indicates a problem.
+    """
+    configure_logging(args.log_level)
+    LOG.info("Trying all crashes in bucket %d until one reduces", args.input)
+    # ensure --tool is reset for each call to grizzly.reduce.crash.main()
+    orig_tool = args.tool
+
+    # if no crashes in bucket, return success
+    result = Session.EXIT_SUCCESS
+
+    # create a fake CrashEntry used only to download the signature once
+    crash = CrashEntry(0)
+    crash._data = {"bucket": args.input}  # pylint: disable=protected-access
+    try:
+        if args.sig is None:
+            args.sig = str(crash.bucket_path())
+
+        for crash in CrashEntry.iter_bucket(args.input, args.quality):
+            args.input = crash.id
+            args.tool = orig_tool
+
+            # call grizzly.reduce.crash
+            result = crash_main(args)
+            if result == 0:
+                break
+
+    finally:
+        crash.cleanup()
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main(ReduceFuzzManagerIDQualityArgs().parse_args()))

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -598,7 +598,7 @@ class ReduceManager(object):
 
     @classmethod
     def main(cls, args):
-        """CLI for `grizzly.replay`.
+        """CLI for `grizzly.reduce`.
 
         Arguments:
             args (argparse.Namespace): Result from `ReduceArgs.parse_args`.

--- a/grizzly/reduce/crash.py
+++ b/grizzly/reduce/crash.py
@@ -45,18 +45,19 @@ def main(args):
         # default back to UNREDUCED
         # most errors will not be related to the testcase
         # so they should be retried later
-        quality = {
-            Session.EXIT_SUCCESS: FuzzManagerReporter.QUAL_REDUCED_ORIGINAL,
-            Session.EXIT_FAILURE: FuzzManagerReporter.QUAL_NOT_REPRODUCIBLE,
-        }.get(
-            result, FuzzManagerReporter.QUAL_UNREDUCED
-        )
-        LOG.info(
-            "reducer finished -> exit(%d) -> Q%d",
-            result,
-            quality,
-        )
-        crash.testcase_quality = quality
+        if args.fuzzmanager:
+            quality = {
+                Session.EXIT_SUCCESS: FuzzManagerReporter.QUAL_REDUCED_ORIGINAL,
+                Session.EXIT_FAILURE: FuzzManagerReporter.QUAL_NOT_REPRODUCIBLE,
+            }.get(
+                result, FuzzManagerReporter.QUAL_UNREDUCED
+            )
+            LOG.info(
+                "reducer finished -> exit(%d) -> Q%d",
+                result,
+                quality,
+            )
+            crash.testcase_quality = quality
     finally:
         crash.cleanup()
         if bucket is not None:

--- a/grizzly/reduce/crash.py
+++ b/grizzly/reduce/crash.py
@@ -2,223 +2,18 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import json
 from logging import getLogger
-from os import unlink
-from pathlib import Path
-from shutil import rmtree
 import sys
-from tempfile import mkdtemp, mkstemp
-
-from Collector.Collector import Collector
 
 from .args import ReduceFuzzManagerIDArgs
 from .core import ReduceManager
+from ..common.fuzzmanager import Bucket, CrashEntry
 from ..common.reporter import FuzzManagerReporter
 from ..main import configure_logging
 from ..session import Session
 
 
 LOG = getLogger(__name__)
-
-
-class CrashEntry(object):
-    """Get the CrashEntry data for the specified CrashManager crash.
-
-    Attributes:
-        see crashmanager.serializers.CrashEntrySerializer
-    """
-
-    def __init__(self, crash_id):
-        """Initialize CrashEntry.
-
-        Arguments:
-            crash_id (int): ID of the requested crash on the server side
-        """
-        self._coll = Collector()
-        self._url = "%s://%s:%d/crashmanager/rest/crashes/%d/" % (
-            self._coll.serverProtocol,
-            self._coll.serverHost,
-            self._coll.serverPort,
-            crash_id,
-        )
-        self._data = None
-        self._tc_filename = None
-        self._sig_filename = None
-
-    @classmethod
-    def iter_bucket(cls, bucket_id, quality_filter=None):
-        """Fetch all crash IDs for the specified FuzzManager bucket.
-        Only crashes with testcases are returned.
-
-        Args:
-            bucket_id (int): ID of the requested bucket on the server side
-            quality_filter (int): Filter crashes by quality value (None for all)
-
-        Returns:
-            generator: generator of crash ID (int)
-        """
-        coll = Collector()
-
-        def _get_results(endpoint, params=None):
-            """
-            Function to get paginated results from FuzzManager
-
-            Args:
-                endpoint (str): FuzzManager REST API to query (eg. "crashes").
-                params (dict): Params to pass through to requests.get
-
-            Returns:
-                generator: objects returned by FuzzManager (as dicts)
-            """
-            LOG.debug("first request to /%s/", endpoint)
-
-            url = "%s://%s:%d/crashmanager/rest/%s/" \
-                % (coll.serverProtocol, coll.serverHost, coll.serverPort, endpoint)
-
-            response = coll.get(url, params=params).json()
-
-            while True:
-                LOG.debug("got %d/%d %s", len(response["results"]), response["count"], endpoint)
-                while response["results"]:
-                    yield response["results"].pop()
-
-                if response["next"] is None:
-                    break
-
-                LOG.debug("next request to /%s/", endpoint)
-                response = coll.get(response["next"]).json()
-
-        # Get all crashes for bucket
-        query_args = [
-            ("op", "AND"),
-            ("bucket", bucket_id),
-        ]
-        if quality_filter is not None:
-            query_args.append(("testcase__quality", quality_filter))
-        query = json.dumps(dict(query_args))
-
-        n_yielded = 0
-        for crash in _get_results("crashes", params={"query": query, "include_raw": "0"}):
-
-            if not crash["testcase"]:
-                LOG.warning("crash %d has no testcase, skipping", crash["id"])
-                continue
-
-            n_yielded += 1
-            LOG.debug("yielding crash #%d", n_yielded)
-            result = cls(crash["id"])
-            result._data = crash  # pylint: disable=protected-access
-            yield result
-
-    def __getattr__(self, name):
-        if self._data is None:
-            self._data = self._coll.get(self._url, params={"include_raw": "0"}).json()
-        if name not in self._data:
-            raise AttributeError(
-                "'%s' object has no attribute '%s' (has: %s)"
-                % (type(self).__name__, name, list(self._data))
-            )
-        return self._data[name]
-
-    def __setattr__(self, name, value):
-        if name.startswith("_"):
-            super().__setattr__(name, value)
-            return
-        if name != "testcase_quality":
-            raise AttributeError("can't set attribute")
-        self._coll.patch(self._url, data={name: value})
-        self._data[name] = value
-
-    def cleanup(self):
-        """Cleanup any resources held by this instance.
-
-        Arguments:
-            None
-
-        Returns:
-            None
-        """
-        if self._tc_filename is not None:
-            self._tc_filename.unlink()
-        if self._sig_filename is not None:
-            rmtree(str(self._sig_filename.parent))
-
-    def testcase_path(self):
-        """Download the testcase data from CrashManager.
-
-        Arguments:
-            None
-
-        Returns:
-            Path: Path on disk where testcase exists.
-        """
-        if self._tc_filename is not None:
-            return self._tc_filename
-
-        dlurl = self._url + "download/"
-        response = self._coll.get(dlurl)
-
-        if "content-disposition" not in response.headers:
-            raise RuntimeError("Server sent malformed response: %r" % (response,))
-
-        handle, filename = mkstemp(
-            prefix="grizzly-reduce-%d-" % (self.id,), suffix=Path(self.testcase).suffix
-        )
-        try:
-            with open(handle, "wb") as output:
-                output.write(response.content)
-        except:  # noqa pylint: disable=bare-except
-            unlink(filename)
-            raise
-        self._tc_filename = Path(filename)
-        return self._tc_filename
-
-    def bucket_path(self):
-        """Download the bucket data from CrashManager.
-
-        Arguments:
-            None
-
-        Returns:
-            Path: Path on disk where signature exists.
-        """
-        if self._sig_filename is not None:
-            return self._sig_filename
-
-        if self.bucket is None:
-            return None
-
-        bucket_url = "%s://%s:%d/crashmanager/rest/buckets/%d/" % (
-            self._coll.serverProtocol,
-            self._coll.serverHost,
-            self._coll.serverPort,
-            self.bucket,
-        )
-        bucket_data = self._coll.get(bucket_url).json()
-
-        tmpd = Path(mkdtemp(prefix="grizzly-reduce-"))
-        try:
-            sig_basename = "%d.signature" % (self.bucket,)
-            sig_filename = tmpd / sig_basename
-            sig_filename.write_text(bucket_data["signature"])
-            sigmeta_filename = sig_filename.with_suffix(".metadata")
-            sigmeta_filename.write_text(
-                json.dumps(
-                    {
-                        "size": bucket_data["size"],
-                        "frequent": bucket_data["frequent"],
-                        "shortDescription": bucket_data["shortDescription"],
-                        "testcase__quality": bucket_data["best_quality"],
-                    }
-                )
-            )
-        except:  # noqa pylint: disable=bare-except
-            rmtree(str(tmpd))
-            raise
-
-        self._sig_filename = sig_filename
-        return self._sig_filename
 
 
 def main(args):
@@ -232,11 +27,13 @@ def main(args):
     """
     configure_logging(args.log_level)
     crash = CrashEntry(args.input)
+    bucket = None
     try:
         # download the crash
         args.input = str(crash.testcase_path())
-        if args.sig is None and crash.bucket_path() is not None:
-            args.sig = str(crash.bucket_path())
+        if args.sig is None and crash.bucket is not None:
+            bucket = Bucket(crash.bucket)
+            args.sig = str(bucket.signature_path())
         if args.tool is None:
             args.tool = crash.tool
 
@@ -249,7 +46,7 @@ def main(args):
         # most errors will not be related to the testcase
         # so they should be retried later
         quality = {
-            Session.EXIT_SUCCESS: FuzzManagerReporter.QUAL_REDUCED_RESULT,
+            Session.EXIT_SUCCESS: FuzzManagerReporter.QUAL_REDUCED_ORIGINAL,
             Session.EXIT_FAILURE: FuzzManagerReporter.QUAL_NOT_REPRODUCIBLE,
         }.get(
             result, FuzzManagerReporter.QUAL_UNREDUCED
@@ -262,6 +59,8 @@ def main(args):
         crash.testcase_quality = quality
     finally:
         crash.cleanup()
+        if bucket is not None:
+            bucket.cleanup()
     return result
 
 

--- a/grizzly/reduce/crash.py
+++ b/grizzly/reduce/crash.py
@@ -1,0 +1,269 @@
+# coding=utf-8
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
+from logging import getLogger
+from os import unlink
+from pathlib import Path
+from shutil import rmtree
+import sys
+from tempfile import mkdtemp, mkstemp
+
+from Collector.Collector import Collector
+
+from .args import ReduceFuzzManagerIDArgs
+from .core import ReduceManager
+from ..common.reporter import FuzzManagerReporter
+from ..main import configure_logging
+from ..session import Session
+
+
+LOG = getLogger(__name__)
+
+
+class CrashEntry(object):
+    """Get the CrashEntry data for the specified CrashManager crash.
+
+    Attributes:
+        see crashmanager.serializers.CrashEntrySerializer
+    """
+
+    def __init__(self, crash_id):
+        """Initialize CrashEntry.
+
+        Arguments:
+            crash_id (int): ID of the requested crash on the server side
+        """
+        self._coll = Collector()
+        self._url = "%s://%s:%d/crashmanager/rest/crashes/%d/" % (
+            self._coll.serverProtocol,
+            self._coll.serverHost,
+            self._coll.serverPort,
+            crash_id,
+        )
+        self._data = None
+        self._tc_filename = None
+        self._sig_filename = None
+
+    @classmethod
+    def iter_bucket(cls, bucket_id, quality_filter=None):
+        """Fetch all crash IDs for the specified FuzzManager bucket.
+        Only crashes with testcases are returned.
+
+        Args:
+            bucket_id (int): ID of the requested bucket on the server side
+            quality_filter (int): Filter crashes by quality value (None for all)
+
+        Returns:
+            generator: generator of crash ID (int)
+        """
+        coll = Collector()
+
+        def _get_results(endpoint, params=None):
+            """
+            Function to get paginated results from FuzzManager
+
+            Args:
+                endpoint (str): FuzzManager REST API to query (eg. "crashes").
+                params (dict): Params to pass through to requests.get
+
+            Returns:
+                generator: objects returned by FuzzManager (as dicts)
+            """
+            LOG.debug("first request to /%s/", endpoint)
+
+            url = "%s://%s:%d/crashmanager/rest/%s/" \
+                % (coll.serverProtocol, coll.serverHost, coll.serverPort, endpoint)
+
+            response = coll.get(url, params=params).json()
+
+            while True:
+                LOG.debug("got %d/%d %s", len(response["results"]), response["count"], endpoint)
+                while response["results"]:
+                    yield response["results"].pop()
+
+                if response["next"] is None:
+                    break
+
+                LOG.debug("next request to /%s/", endpoint)
+                response = coll.get(response["next"]).json()
+
+        # Get all crashes for bucket
+        query_args = [
+            ("op", "AND"),
+            ("bucket", bucket_id),
+        ]
+        if quality_filter is not None:
+            query_args.append(("testcase__quality", quality_filter))
+        query = json.dumps(dict(query_args))
+
+        n_yielded = 0
+        for crash in _get_results("crashes", params={"query": query, "include_raw": "0"}):
+
+            if not crash["testcase"]:
+                LOG.warning("crash %d has no testcase, skipping", crash["id"])
+                continue
+
+            n_yielded += 1
+            LOG.debug("yielding crash #%d", n_yielded)
+            result = cls(crash["id"])
+            result._data = crash  # pylint: disable=protected-access
+            yield result
+
+    def __getattr__(self, name):
+        if self._data is None:
+            self._data = self._coll.get(self._url, params={"include_raw": "0"}).json()
+        if name not in self._data:
+            raise AttributeError(
+                "'%s' object has no attribute '%s' (has: %s)"
+                % (type(self).__name__, name, list(self._data))
+            )
+        return self._data[name]
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+            return
+        if name != "testcase_quality":
+            raise AttributeError("can't set attribute")
+        self._coll.patch(self._url, data={name: value})
+        self._data[name] = value
+
+    def cleanup(self):
+        """Cleanup any resources held by this instance.
+
+        Arguments:
+            None
+
+        Returns:
+            None
+        """
+        if self._tc_filename is not None:
+            self._tc_filename.unlink()
+        if self._sig_filename is not None:
+            rmtree(str(self._sig_filename.parent))
+
+    def testcase_path(self):
+        """Download the testcase data from CrashManager.
+
+        Arguments:
+            None
+
+        Returns:
+            Path: Path on disk where testcase exists.
+        """
+        if self._tc_filename is not None:
+            return self._tc_filename
+
+        dlurl = self._url + "download/"
+        response = self._coll.get(dlurl)
+
+        if "content-disposition" not in response.headers:
+            raise RuntimeError("Server sent malformed response: %r" % (response,))
+
+        handle, filename = mkstemp(
+            prefix="grizzly-reduce-%d-" % (self.id,), suffix=Path(self.testcase).suffix
+        )
+        try:
+            with open(handle, "wb") as output:
+                output.write(response.content)
+        except:  # noqa pylint: disable=bare-except
+            unlink(filename)
+            raise
+        self._tc_filename = Path(filename)
+        return self._tc_filename
+
+    def bucket_path(self):
+        """Download the bucket data from CrashManager.
+
+        Arguments:
+            None
+
+        Returns:
+            Path: Path on disk where signature exists.
+        """
+        if self._sig_filename is not None:
+            return self._sig_filename
+
+        if self.bucket is None:
+            return None
+
+        bucket_url = "%s://%s:%d/crashmanager/rest/buckets/%d/" % (
+            self._coll.serverProtocol,
+            self._coll.serverHost,
+            self._coll.serverPort,
+            self.bucket,
+        )
+        bucket_data = self._coll.get(bucket_url).json()
+
+        tmpd = Path(mkdtemp(prefix="grizzly-reduce-"))
+        try:
+            sig_basename = "%d.signature" % (self.bucket,)
+            sig_filename = tmpd / sig_basename
+            sig_filename.write_text(bucket_data["signature"])
+            sigmeta_filename = sig_filename.with_suffix(".metadata")
+            sigmeta_filename.write_text(
+                json.dumps(
+                    {
+                        "size": bucket_data["size"],
+                        "frequent": bucket_data["frequent"],
+                        "shortDescription": bucket_data["shortDescription"],
+                        "testcase__quality": bucket_data["best_quality"],
+                    }
+                )
+            )
+        except:  # noqa pylint: disable=bare-except
+            rmtree(str(tmpd))
+            raise
+
+        self._sig_filename = sig_filename
+        return self._sig_filename
+
+
+def main(args):
+    """CLI for `grizzly.reduce.crash`.
+
+    Arguments:
+        args (argparse.Namespace): Result from `ReduceArgs.parse_args`.
+
+    Returns:
+        int: 0 for success. non-0 indicates a problem.
+    """
+    configure_logging(args.log_level)
+    crash = CrashEntry(args.input)
+    try:
+        # download the crash
+        args.input = str(crash.testcase_path())
+        if args.sig is None and crash.bucket_path() is not None:
+            args.sig = str(crash.bucket_path())
+        if args.tool is None:
+            args.tool = crash.tool
+
+        # call grizzly.reduce
+        result = ReduceManager.main(args)
+
+        # update quality
+        # map Session.EXIT_* -> FuzzManagerReporter.QUAL_*
+        # default back to UNREDUCED
+        # most errors will not be related to the testcase
+        # so they should be retried later
+        quality = {
+            Session.EXIT_SUCCESS: FuzzManagerReporter.QUAL_REDUCED_RESULT,
+            Session.EXIT_FAILURE: FuzzManagerReporter.QUAL_NOT_REPRODUCIBLE,
+        }.get(
+            result, FuzzManagerReporter.QUAL_UNREDUCED
+        )
+        LOG.info(
+            "reducer finished -> exit(%d) -> Q%d",
+            result,
+            quality,
+        )
+        crash.testcase_quality = quality
+    finally:
+        crash.cleanup()
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main(ReduceFuzzManagerIDArgs().parse_args()))

--- a/grizzly/reduce/test_main.py
+++ b/grizzly/reduce/test_main.py
@@ -2,9 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-# pylint: disable=protected-access
-"""Unit tests for `grizzly.reduce.main`.
-"""
+"""Unit tests for `grizzly.reduce.main`."""
 import json
 from logging import getLogger
 from pathlib import Path

--- a/grizzly/reduce/test_main_fm.py
+++ b/grizzly/reduce/test_main_fm.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Unit tests for `grizzly.reduce.crash` and `grizzly.reduce.bucket`."""
+from copy import deepcopy
+from logging import getLogger
+
+import pytest
+
+from .crash import main as crash_main
+from .bucket import main as bucket_main
+
+
+LOG = getLogger(__name__)
+pytestmark = pytest.mark.usefixtures("tmp_path_fm_config")
+
+
+@pytest.mark.parametrize(
+    "arg_sig, arg_tool, crash_bucket, result_sig, result_tool",
+    [
+        # crash id is downloaded and core.main is called with the path
+        (None, None, None, None, "test-tool"),
+        # crash in bucket, bucket will be downloaded and passed to --sig
+        (None, None, 789, "test_sig.json", "test-tool"),
+        # crash in bucket, --sig is respected
+        ("arg_sig.json", None, 789, "arg_sig.json", "test-tool"),
+        # --tool respected
+        (None, "tool2", None, None, "tool2"),
+
+    ]
+)
+def test_crash_main(mocker, arg_sig, arg_tool, crash_bucket, result_sig, result_tool):
+    """tests for `grizzly.reduce.crash.main`"""
+    mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    crash = mocker.patch("grizzly.reduce.crash.CrashEntry", autospec=True)
+    bucket = mocker.patch("grizzly.reduce.crash.Bucket", autospec=True)
+    mocker.patch("grizzly.reduce.crash.ReduceManager", autospec=True)
+    crash.return_value.testcase_path.return_value = "test_path.zip"
+    crash.return_value.bucket = crash_bucket
+    crash.return_value.tool = "test-tool"
+    bucket.return_value.signature_path.return_value = "test_sig.json"
+
+    args = mocker.Mock(
+        input=12345,
+        sig=arg_sig,
+        tool=arg_tool,
+    )
+    crash_main(args)
+    assert args.input == "test_path.zip"
+    assert args.sig == result_sig
+    assert args.tool == result_tool
+
+
+@pytest.mark.parametrize(
+    "mgr_exit_code, quality",
+    [
+        (0, 1),
+        (1, 5),
+        (2, 5),
+        (3, 5),
+        (4, 5),
+        (5, 10),
+    ]
+)
+def test_crash_main_quality(mocker, mgr_exit_code, quality):
+    """test that quality is updated"""
+    mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    crash = mocker.patch("grizzly.reduce.crash.CrashEntry", autospec=True)
+    mocker.patch("grizzly.reduce.crash.Bucket", autospec=True)
+    mgr = mocker.patch("grizzly.reduce.crash.ReduceManager", autospec=True)
+    crash.return_value.testcase_path.return_value = "test_path.zip"
+    crash.return_value.bucket = None
+    crash.return_value.tool = "test-tool"
+    mgr.main.return_value = mgr_exit_code
+
+    args = mocker.Mock(
+        input=12345,
+        sig=None,
+        tool=None,
+    )
+    assert crash_main(args) == mgr_exit_code
+    assert crash.return_value.testcase_quality == quality
+
+
+@pytest.mark.parametrize(
+    "crashes, main_exit_codes, result, arg_sig, arg_tool",
+    [
+        # no crashes -> success
+        ([], [], 0, None, None),
+        # 1 crash fails -> no success
+        ([(123, "test-tool")], [1], 1, None, None),
+        # second of 3 succeeds -> success
+        ([(123, "test-tool"), (456, "test-tool2")], [1, 0], 0, None, None),
+        # --sig is respected
+        ([(123, "test-tool")], [0], 0, "test_sig2.json", None),
+        # --tool is respected
+        ([(123, "test-tool")], [0], 0, None, "test-tool-arg"),
+    ]
+)
+def test_bucket_main(mocker, crashes, main_exit_codes, result, arg_sig, arg_tool):
+    """tests for `grizzly.reduce.crash.main`"""
+    call_args = []
+
+    def copy_args(args):
+        call_args.append(deepcopy(args))
+        return main_exit_codes[main.call_count - 1]
+    mocker.patch("grizzly.common.fuzzmanager.Collector", autospec=True)
+    bucket = mocker.patch("grizzly.reduce.bucket.Bucket", autospec=True)
+    main = mocker.patch("grizzly.reduce.bucket.crash_main", autospec=True,
+                        side_effect=copy_args)
+    bucket.return_value.signature_path.return_value = "test_sig.json"
+    bucket.return_value.iter_crashes.return_value = [
+        mocker.Mock(crash_id=crash, tool=tool) for crash, tool in crashes
+    ]
+
+    args = mocker.Mock(
+        input=789,
+        sig=arg_sig,
+        tool=arg_tool,
+    )
+    bucket_main(args)
+    assert main.call_count == len(main_exit_codes)
+    for idx, (crash, tool) in enumerate(crashes[:main.call_count]):
+        assert call_args[idx].input == crash
+        if arg_tool is not None:
+            assert call_args[idx].tool == arg_tool
+        else:
+            assert call_args[idx].tool is None
+        if arg_sig is not None:
+            assert call_args[idx].sig == arg_sig
+        else:
+            assert call_args[idx].sig == "test_sig.json"

--- a/grizzly/reduce/test_reduce.py
+++ b/grizzly/reduce/test_reduce.py
@@ -694,7 +694,7 @@ def test_quality_update(mocker, tmp_path):
     mocker.patch("grizzly.common.reporter.Collector")
     reporter = mocker.patch("grizzly.reduce.core.FuzzManagerReporter")
     reporter.QUAL_REDUCED_RESULT = 0
-    update_coll = mocker.patch("grizzly.reduce.core.Collector")
+    update_coll = mocker.patch("grizzly.common.fuzzmanager.Collector")
     target = mocker.Mock(spec=Target)
     target.relaunch = 1
     try:


### PR DESCRIPTION
This also adds tested FuzzManager access code to `grizzly.common`, which could be used for a `grizzly.replay.crash` in the future.