### PR TITLE
[grizzly.reduce] Log launch errors to /tmp instead of trying to reportto FuzzManager (which will likely fail).

### DIFF
--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -22,7 +22,7 @@ from ..common.reporter import FilesystemReporter, FuzzManagerReporter
 from ..common.storage import TestCaseLoadFailure, TestFile
 from ..common.utils import grz_tmp
 from ..main import configure_logging
-from ..replay import ReplayManager, ReplayResult
+from ..replay import ReplayManager
 from ..session import Session
 from ..target import load as load_target, TargetLaunchError, TargetLaunchTimeout
 from .exceptions import GrizzlyReduceBaseException, NotReproducible

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -234,9 +234,10 @@ class ReduceManager(object):
                     )
                 except (TargetLaunchError, TargetLaunchTimeout) as exc:
                     if isinstance(exc, TargetLaunchError) and exc.report:
-                        self.report([ReplayResult(exc.report, None, [], False)],
-                                    testcases, self._stats.copy(stats))
-                        exc.report.cleanup()
+                        path = grz_tmp("launch_failures")
+                        LOG.error("Logs can be found here %r", path)
+                        reporter = FilesystemReporter(path, major_bucket=False)
+                        reporter.submit([], exc.report)
                     raise
                 try:
                     stats.add_iterations(replay.status.iteration)
@@ -461,11 +462,10 @@ class ReduceManager(object):
 
                             except TargetLaunchError as exc:
                                 if exc.report:
-                                    self.report(
-                                        [ReplayResult(exc.report, None, [], False)],
-                                        reduction,
-                                        self._stats.copy(strategy_stats))
-                                    exc.report.cleanup()
+                                    path = grz_tmp("launch_failures")
+                                    LOG.error("Logs can be found here %r", path)
+                                    reporter = FilesystemReporter(path, major_bucket=False)
+                                    reporter.submit([], exc.report)
                                 raise
                             finally:
                                 if not keep_reduction:


### PR DESCRIPTION
This is how `grizzly.replay` works too.