### PR TITLE
Update Target relauch/shutdown

### DIFF
--- a/grizzly/common/harness.html
+++ b/grizzly/common/harness.html
@@ -5,7 +5,6 @@
 <title>&#x1f43b; &sdot; Grizzly &sdot; &#x1f98a;</title>
 <script>
 let close_after, limit_tmr, time_limit
-let forced_close = true
 let sub = null
 
 let grzDump = (msg) => {
@@ -42,13 +41,18 @@ let main = () => {
   }
 
   if ((close_after !== undefined) && (close_after-- < 1)) {
-    grzDump('Hit close limit.')
-    if (forced_close) {
-      // use window.open() to call `/grz_close_browser` then close the harness
-      // this helps catch crashes that are triggered when the test window closes
-      window.open('/grz_close_browser')
-    }
-    setTimeout(window.close, 0)
+    grzDump('Iteration limit hit.')
+    setBanner('Iteration limit hit. Browser should close momentarily...<br>' +
+              'Warning: Any additional open tabs can block browser from closing.')
+    try { window.focus() } catch(e) { }
+    let xhr = new XMLHttpRequest()
+    // indicate test is complete by requesting `/grz_next_test`
+    try { xhr.open('GET', '/grz_next_test', true) } catch (e) {}
+    xhr.onabort = () => { window.close() }
+    xhr.onerror = () => { window.close() }
+    xhr.onload = () => { window.close() }
+    // close the harness to catch crashes that are triggered when the browser closes
+    setTimeout(() => { xhr.send() }, 100)
     return
   }
 
@@ -86,10 +90,6 @@ window.addEventListener('load', () => {
         time_limit = Number(v)
       } else if (k === 'close_after') {
         close_after = Number(v)
-      } else if (k === 'forced_close') {
-        if (v === 'false' || v === '0') {
-          forced_close = false
-        }
       } else {
         grzDump(`unknown arg '${k}'`)
       }

--- a/grizzly/common/harness.html
+++ b/grizzly/common/harness.html
@@ -47,7 +47,7 @@ let main = () => {
     try { window.focus() } catch(e) { }
     let xhr = new XMLHttpRequest()
     // indicate test is complete by requesting `/grz_next_test`
-    try { xhr.open('GET', '/grz_next_test', true) } catch (e) {}
+    xhr.open('GET', '/grz_next_test', true)
     xhr.onabort = () => { window.close() }
     xhr.onerror = () => { window.close() }
     xhr.onload = () => { window.close() }

--- a/grizzly/common/runner.py
+++ b/grizzly/common/runner.py
@@ -134,14 +134,13 @@ class Runner(object):
         self._tests_run = 0
 
     @staticmethod
-    def location(srv_path, srv_port, close_after=None, forced_close=True, timeout=None):
+    def location(srv_path, srv_port, close_after=None, timeout=None):
         """Build a valid URL to pass to a browser.
 
         Args:
             srv_path (str): Path segment of the URL
             srv_port (int): Server listening port
             close_after (int): Harness argument.
-            forced_close (bool): Harness argument.
             timeout (int): Harness argument.
 
         Returns:
@@ -153,8 +152,6 @@ class Runner(object):
         if close_after is not None:
             assert close_after >= 0
             args.append("close_after=%d" % (close_after,))
-        if not forced_close:
-            args.append("forced_close=0")
         if timeout is not None:
             assert timeout >= 0
             args.append("timeout=%d" % (timeout * 1000,))

--- a/grizzly/common/runner.py
+++ b/grizzly/common/runner.py
@@ -215,7 +215,7 @@ class Runner(object):
                 self._target.dump_coverage()
             # relaunch check
             if self._tests_run >= self._relaunch:
-                assert self._tests_run >= self._relaunch
+                assert self._tests_run == self._relaunch
                 server_map.dynamic.pop("grz_empty", None)
                 LOG.debug("relaunch/shutdown limit hit")
                 # ideally all browser tabs should be closed at this point

--- a/grizzly/common/runner.py
+++ b/grizzly/common/runner.py
@@ -227,6 +227,8 @@ class Runner(object):
                         break
                     # wait 2 seconds (4 passes) before attempting idle exit
                     if close_delay > 3 and self._target.is_idle(10):
+                        # NOTE: this will always trigger on systems where the
+                        # browser does not exit when the last window is closed
                         LOG.debug("target idle")
                         break
                     # delay to help catch shutdown related crashes, LSan, etc.

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -170,7 +170,7 @@ def test_runner_04(mocker):
 def test_runner_05(mocker):
     """test reporting failures"""
     server = mocker.Mock(spec=Sapphire)
-    target = mocker.Mock(spec=Target)
+    target = mocker.Mock(spec=Target, launch_timeout=10)
     target.monitor.is_healthy.return_value = False
     serv_files = ["file.bin"]
     server.serve_path.return_value = (SERVED_REQUEST, serv_files)
@@ -178,6 +178,7 @@ def test_runner_05(mocker):
     runner = Runner(server, target)
     # test FAILURE
     target.detect_failure.return_value = target.RESULT_FAILURE
+    runner.launch("http://a/")
     result = runner.run([], ServerMap(), testcase)
     assert result.attempted
     assert result.status == RunResult.FAILED
@@ -185,6 +186,7 @@ def test_runner_05(mocker):
     assert not result.timeout
     # test IGNORED
     target.detect_failure.return_value = target.RESULT_IGNORED
+    runner.launch("http://a/")
     result = runner.run([], ServerMap(), testcase)
     assert result.attempted
     assert result.status == RunResult.IGNORED
@@ -193,6 +195,7 @@ def test_runner_05(mocker):
     # failure before serving landing page
     server.serve_path.return_value = (SERVED_REQUEST, ["harness"])
     target.detect_failure.return_value = target.RESULT_FAILURE
+    runner.launch("http://a/")
     result = runner.run([], ServerMap(), testcase)
     assert not result.attempted
     assert result.status == RunResult.FAILED

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -16,19 +16,21 @@ from ..target import Target, TargetLaunchError, TargetLaunchTimeout
 
 def test_runner_01(mocker, tmp_path):
     """test Runner()"""
-    fake_time = mocker.patch("grizzly.common.runner.time", autospec=True)
+    mocker.patch("grizzly.common.runner.time", autospec=True, side_effect=range(10))
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
     target.detect_failure.return_value = target.RESULT_NONE
-    runner = Runner(server, target)
+    runner = Runner(server, target, relaunch=10)
     assert runner._idle is None
+    assert runner._relaunch == 10
+    assert runner._tests_run == 0
     serv_files = ["a.bin", "/another/file.bin"]
     testcase = mocker.Mock(spec=TestCase, landing_page=serv_files[0], optional=[])
     # all files served
-    fake_time.side_effect = (1, 2)
     server.serve_path.return_value = (SERVED_ALL, serv_files)
     result = runner.run([], ServerMap(), testcase)
     assert result.attempted
+    assert runner._tests_run == 1
     assert result.duration == 1
     assert result.initial
     assert result.status is None
@@ -38,10 +40,10 @@ def test_runner_01(mocker, tmp_path):
     assert target.dump_coverage.call_count == 0
     assert testcase.dump.call_count == 1
     # some files served
-    fake_time.side_effect = (1, 2)
     server.serve_path.return_value = (SERVED_REQUEST, serv_files)
     result = runner.run([], ServerMap(), testcase, coverage=True)
     assert result.attempted
+    assert runner._tests_run == 2
     assert not result.initial
     assert result.status is None
     assert result.served == serv_files
@@ -49,13 +51,13 @@ def test_runner_01(mocker, tmp_path):
     assert target.close.call_count == 0
     assert target.dump_coverage.call_count == 1
     # existing test path
-    fake_time.side_effect = (1, 2)
     testcase.reset_mock()
     tc_path = (tmp_path / "tc")
     tc_path.mkdir()
     server.serve_path.return_value = (SERVED_ALL, serv_files)
     result = runner.run([], ServerMap(), testcase, test_path=str(tc_path))
     assert result.attempted
+    assert runner._tests_run == 3
     assert not result.initial
     assert result.status is None
     assert target.close.call_count == 0
@@ -63,6 +65,70 @@ def test_runner_01(mocker, tmp_path):
     tc_path.is_dir()
 
 def test_runner_02(mocker):
+    """test Runner.run() relaunch"""
+    mocker.patch("grizzly.common.runner.time", autospec=True, return_value=1)
+    mocker.patch("grizzly.common.runner.sleep", autospec=True)
+    server = mocker.Mock(spec=Sapphire)
+    target = mocker.Mock(spec=Target)
+    target.detect_failure.return_value = target.RESULT_NONE
+    serv_files = ["a.bin"]
+    server.serve_path.return_value = (SERVED_ALL, serv_files)
+    testcase = mocker.Mock(spec=TestCase, landing_page=serv_files[0], optional=[])
+    # single run/iteration relaunch (not idle exit)
+    target.is_idle.return_value = False
+    runner = Runner(server, target, relaunch=1)
+    assert runner._relaunch == 1
+    smap = ServerMap()
+    result = runner.run([], smap, testcase)
+    assert result.attempted
+    assert result.initial
+    assert target.close.call_count == 1
+    assert target.is_idle.call_count > 0
+    assert target.monitor.is_healthy.call_count > 0
+    assert result.status is None
+    assert result.served == serv_files
+    assert not smap.dynamic
+    assert smap.redirect.get("grz_next_test").target == "grz_empty"
+    assert not result.timeout
+    target.reset_mock()
+    testcase.reset_mock()
+    # single run/iteration relaunch (idle exit)
+    target.is_idle.return_value = True
+    runner = Runner(server, target, relaunch=1)
+    assert runner._relaunch == 1
+    result = runner.run([], ServerMap(), testcase)
+    assert result.attempted
+    assert target.close.call_count == 1
+    assert target.monitor.is_healthy.call_count > 0
+    target.reset_mock()
+    testcase.reset_mock()
+    # multiple runs/iterations relaunch (is_healty exit)
+    runner = Runner(server, target, relaunch=3)
+    target.monitor.is_healthy.return_value = False
+    for _ in range(2):
+        smap = ServerMap()
+        result = runner.run([], smap, testcase)
+        assert result.attempted
+        assert target.close.call_count == 0
+        assert target.monitor.is_healthy.call_count == 0
+        assert result.status is None
+        assert result.served == serv_files
+        assert not result.timeout
+        assert not smap.dynamic
+        assert "grz_next_test" not in smap.redirect
+    smap = ServerMap()
+    result = runner.run([], smap, testcase)
+    assert runner._tests_run == 3
+    assert result.attempted
+    assert target.close.call_count == 1
+    assert target.is_idle.call_count == 0
+    assert target.monitor.is_healthy.call_count == 1
+    assert result.status is None
+    assert result.served == serv_files
+    assert not smap.dynamic
+    assert smap.redirect.get("grz_next_test").target == "grz_empty"
+
+def test_runner_03(mocker):
     """test Runner() errors"""
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
@@ -88,7 +154,7 @@ def test_runner_02(mocker):
     assert result.served
     assert target.close.call_count == 1
 
-def test_runner_03(mocker):
+def test_runner_04(mocker):
     """test reporting timeout"""
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
@@ -101,10 +167,11 @@ def test_runner_03(mocker):
     assert result.served == serv_files
     assert result.timeout
 
-def test_runner_04(mocker):
+def test_runner_05(mocker):
     """test reporting failures"""
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
+    target.monitor.is_healthy.return_value = False
     serv_files = ["file.bin"]
     server.serve_path.return_value = (SERVED_REQUEST, serv_files)
     testcase = mocker.Mock(spec=TestCase, landing_page=serv_files[0], optional=[])
@@ -132,21 +199,21 @@ def test_runner_04(mocker):
     assert result.served
     assert not result.timeout
 
-def test_runner_05(mocker):
+def test_runner_06(mocker):
     """test Runner() with idle checking"""
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
     target.detect_failure.return_value = target.RESULT_NONE
     serv_files = ["/fake/file", "/another/file.bin"]
     server.serve_path.return_value = (SERVED_REQUEST, serv_files)
-    runner = Runner(server, target, idle_threshold=0.01, idle_delay=0.01)
+    runner = Runner(server, target, idle_threshold=0.01, idle_delay=0.01, relaunch=10)
     assert runner._idle is not None
     result = runner.run([], ServerMap(), mocker.Mock(spec=TestCase, landing_page=serv_files[0], optional=[]))
     assert result.status is None
     assert result.attempted
     assert target.close.call_count == 0
 
-def test_runner_06(mocker):
+def test_runner_07(mocker):
     """test Runner._keep_waiting()"""
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
@@ -171,7 +238,7 @@ def test_runner_06(mocker):
     target.monitor.is_healthy.return_value = False
     assert not runner._keep_waiting()
 
-def test_runner_07():
+def test_runner_08():
     """test Runner.location()"""
     result = Runner.location("a.html", 34567)
     assert result == "http://127.0.0.1:34567/a.html"
@@ -186,7 +253,7 @@ def test_runner_07():
     result = Runner.location("a.html", 9999, close_after=10, forced_close=False, timeout=60)
     assert result == "http://127.0.0.1:9999/a.html?close_after=10&forced_close=0&timeout=60000"
 
-def test_runner_08(mocker):
+def test_runner_09(mocker):
     """test Runner.launch()"""
     server = mocker.Mock(spec=Sapphire, port=0x1337)
     target = mocker.Mock(spec=Target, launch_timeout=30)
@@ -209,12 +276,12 @@ def test_runner_08(mocker):
         runner.launch("http://a/", max_retries=3)
     assert target.launch.call_count == 3
 
-def test_runner_09(mocker, tmp_path):
+def test_runner_10(mocker, tmp_path):
     """test Runner.run() adding includes to testcase"""
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
     target.detect_failure.return_value = target.RESULT_NONE
-    runner = Runner(server, target)
+    runner = Runner(server, target, relaunch=10)
     # create test files
     inc_path1 = (tmp_path / "include")
     inc_path1.mkdir()

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -246,12 +246,10 @@ def test_runner_08():
     assert result == "http://127.0.0.1:34567/a.html"
     result = Runner.location("a.html", 34567, close_after=10)
     assert result == "http://127.0.0.1:34567/a.html?close_after=10"
-    result = Runner.location("a.html", 34567, close_after=10, forced_close=False)
-    assert result == "http://127.0.0.1:34567/a.html?close_after=10&forced_close=0"
-    result = Runner.location("a.html", 34567, forced_close=False)
-    assert result == "http://127.0.0.1:34567/a.html?forced_close=0"
-    result = Runner.location("a.html", 9999, close_after=10, forced_close=False, timeout=60)
-    assert result == "http://127.0.0.1:9999/a.html?close_after=10&forced_close=0&timeout=60000"
+    result = Runner.location("a.html", 9999, timeout=60)
+    assert result == "http://127.0.0.1:9999/a.html?timeout=60000"
+    result = Runner.location("a.html", 9999, close_after=10, timeout=60)
+    assert result == "http://127.0.0.1:9999/a.html?close_after=10&timeout=60000"
 
 def test_runner_09(mocker):
     """test Runner.launch()"""

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # pylint: disable=protected-access
+from itertools import count
 from os.path import join as pathjoin
 
 from pytest import raises
@@ -16,7 +17,7 @@ from ..target import Target, TargetLaunchError, TargetLaunchTimeout
 
 def test_runner_01(mocker, tmp_path):
     """test Runner()"""
-    mocker.patch("grizzly.common.runner.time", autospec=True, side_effect=range(10))
+    mocker.patch("grizzly.common.runner.time", autospec=True, side_effect=count())
     server = mocker.Mock(spec=Sapphire)
     target = mocker.Mock(spec=Target)
     target.detect_failure.return_value = target.RESULT_NONE

--- a/grizzly/main.py
+++ b/grizzly/main.py
@@ -66,7 +66,7 @@ def main(args):
             return Session.EXIT_ARGS
 
         if adapter.RELAUNCH > 0:
-            log.debug("relaunch (%d) set in Adapter", adapter.RELAUNCH)
+            log.info("Relaunch (%d) set in Adapter", adapter.RELAUNCH)
             relaunch = adapter.RELAUNCH
         else:
             relaunch = args.relaunch
@@ -78,7 +78,6 @@ def main(args):
             args.launch_timeout,
             args.log_limit,
             args.memory,
-            relaunch,
             rr=args.rr,
             valgrind=args.valgrind,
             xvfb=args.xvfb)
@@ -87,10 +86,9 @@ def main(args):
             log.info("Using prefs %r", args.prefs)
         adapter.monitor = target.monitor
 
-        if args.coverage and relaunch == 1 and target.forced_close:
+        if args.coverage and relaunch == 1:
             # this is a workaround to avoid not dumping coverage
-            # GRZ_FORCED_CLOSE=0 is also an option but the browser MUST
-            # close itself.
+            # TODO: this may not be needed since moving relaunch into runnner
             raise RuntimeError("Coverage must be run with --relaunch > 1")
 
         log.debug("calling adapter setup()")
@@ -122,7 +120,8 @@ def main(args):
                 reporter,
                 server,
                 target,
-                coverage=args.coverage)
+                coverage=args.coverage,
+                relaunch=relaunch)
             if args.log_level == DEBUG or args.verbose:
                 display_mode = Session.DISPLAY_VERBOSE
             else:

--- a/grizzly/main.py
+++ b/grizzly/main.py
@@ -86,11 +86,6 @@ def main(args):
             log.info("Using prefs %r", args.prefs)
         adapter.monitor = target.monitor
 
-        if args.coverage and relaunch == 1:
-            # this is a workaround to avoid not dumping coverage
-            # TODO: this may not be needed since moving relaunch into runnner
-            raise RuntimeError("Coverage must be run with --relaunch > 1")
-
         log.debug("calling adapter setup()")
         adapter.setup(args.input, iomanager.server_map)
         log.debug("configuring harness")

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -212,7 +212,7 @@ class ReduceManager(object):
             if last_test and len(self.testcases) == 1:
                 continue
 
-            relaunch = self.ANALYSIS_ITERATIONS if use_harness else 1
+            relaunch = self.ANALYSIS_ITERATIONS if last_test else 1
 
             with ReplayManager(
                 self.ignore, self.server, self.target, any_crash=self._any_crash,
@@ -350,7 +350,9 @@ class ReduceManager(object):
                         self.run_reliability_analysis(stats)
                 self._stats.add_info("Analysis", reliability_info)
                 any_success = True  # analysis ran and didn't raise
-            if self._use_harness:
+            # multi part test cases should always use relaunch == 1
+            # since that usually means there is a timing component
+            if self._use_harness and len(self.testcases) == 1:
                 relaunch = min(self._original_relaunch, repeat)
             else:
                 relaunch = 1
@@ -369,6 +371,7 @@ class ReduceManager(object):
                          len(self.strategies))
                 replay = ReplayManager(self.ignore, self.server, self.target,
                                        any_crash=self._any_crash,
+                                       relaunch=relaunch,
                                        signature=self._signature,
                                        use_harness=self._use_harness)
                 strategy = STRATEGIES[strategy](self.testcases)

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -222,7 +222,7 @@ class ReduceManager(object):
             if last_test_only and len(self.testcases) == 1:
                 # Only set `last_test_only` if we have more than one testcase to begin with
                 continue
-            if not use_harness and len(self.testcases) > 1:
+            if not use_harness and (not last_test_only and len(self.testcases) > 1):
                 # Can't run without harness if we have more than one testcase (`last_test_only` will run)
                 continue
 

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -368,7 +368,7 @@ class ReduceManager(object):
                 self._stats.add_info("Analysis", reliability_info)
                 any_success = True  # analysis ran and didn't raise
             # multi part test cases should always use relaunch == 1
-            # since that usually means there is a timing component
+            # since that can mean a delay is required
             if self._use_harness and len(self.testcases) == 1:
                 relaunch = min(self._original_relaunch, repeat)
             else:

--- a/grizzly/reduce/test_main.py
+++ b/grizzly/reduce/test_main.py
@@ -150,33 +150,6 @@ def test_main_launch_error(mocker, exc_type):
         assert reporter.return_value.submit.call_count == 0
 
 
-def test_force_closed(mocker, tmp_path):
-    """test that `forced_close` in testcase metadata is respected"""
-    load_target = mocker.patch("grizzly.reduce.core.load_target")
-    mocker.patch("grizzly.reduce.core.ReduceManager.run", autospec=True)
-    mocker.patch("grizzly.reduce.core.Sapphire", autospec=True)
-    (tmp_path / "test.html").touch()
-    (tmp_path / "test_info.json").write_text(
-        json.dumps({
-            "timestamp": 1,
-            "target": "test.html",
-            "env": {"GRZ_FORCED_CLOSE": "0"}
-        })
-    )
-    args = mocker.Mock(
-        fuzzmanager=False,
-        ignore=[],
-        input=str(tmp_path),
-        min_crashes=1,
-        prefs=None,
-        repeat=1,
-        sig=None,
-        test_index=None,
-    )
-    ReduceManager.main(args)
-    assert load_target.return_value.return_value.forced_close is False
-
-
 @pytest.mark.parametrize("result", ["testprefs", "argprefs"])
 def test_testcase_prefs(mocker, tmp_path, result):
     """test that prefs from testcase are used if --prefs not specified and --prefs

--- a/grizzly/reduce/test_main.py
+++ b/grizzly/reduce/test_main.py
@@ -3,7 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Unit tests for `grizzly.reduce.main`."""
-import json
 from logging import getLogger
 from pathlib import Path
 from shutil import rmtree

--- a/grizzly/reduce/test_reduce.py
+++ b/grizzly/reduce/test_reduce.py
@@ -16,7 +16,7 @@ from pytest import raises
 from sapphire import Sapphire
 from ..common import TestCase, Report
 from ..replay import ReplayResult
-from ..target import Target, TargetLaunchError, TargetLaunchTimeout
+from ..target import Target
 from . import ReduceManager
 from .exceptions import NotReproducible
 from .strategies import Strategy

--- a/grizzly/reduce/test_reduce.py
+++ b/grizzly/reduce/test_reduce.py
@@ -241,7 +241,7 @@ def test_analysis(mocker, tmp_path, harness_last_crashes, harness_crashes,
         expected_iters += 1
     if harness_crashes is not None:
         crashes += [True] * harness_crashes + [False] * (11 - harness_crashes)
-        expected_iters = 1
+        expected_iters += 1
     if no_harness_crashes is not None:
         crashes += [False] * (11 - no_harness_crashes) + [True] * no_harness_crashes
         expected_iters += 1

--- a/grizzly/replay/replay.py
+++ b/grizzly/replay/replay.py
@@ -206,8 +206,7 @@ class ReplayManager(object):
                         location = runner.location(
                             "/grz_harness",
                             self.server.port,
-                            close_after=self.target.rl_reset * test_count,
-                            forced_close=self.target.forced_close)
+                            close_after=self.target.rl_reset * test_count)
                     # The environment from the initial testcase is used because
                     # a sequence of testcases is expected to be run without
                     # relaunching the Target to match the functionality of
@@ -430,9 +429,6 @@ class ReplayManager(object):
                         LOG.info("Using prefs.js from testcase")
                         target.prefs = pathjoin(tmp_prefs, "prefs.js")
                         break
-            if testcases[0].env_vars.get("GRZ_FORCED_CLOSE") == "0":
-                LOG.debug("setting target.forced_close=False")
-                target.forced_close = False
             LOG.debug("starting sapphire server")
             # launch HTTP server used to serve test cases
             with Sapphire(auto_close=1, timeout=args.timeout) as server:

--- a/grizzly/replay/test_main.py
+++ b/grizzly/replay/test_main.py
@@ -79,7 +79,7 @@ def test_main_01(mocker, tmp_path):
     serve_path.return_value = (None, ["test.html"])  # passed to mocked Target.detect_failure
     # setup Target
     load_target = mocker.patch("grizzly.replay.replay.load_target")
-    target = mocker.Mock(spec=Target, binary="bin", launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, binary="bin", launch_timeout=30)
     target.RESULT_FAILURE = Target.RESULT_FAILURE
     target.RESULT_IGNORED = Target.RESULT_IGNORED
     target.RESULT_NONE = Target.RESULT_NONE
@@ -111,7 +111,6 @@ def test_main_01(mocker, tmp_path):
     assert ReplayManager.main(args) == Session.EXIT_SUCCESS
     assert target.reverse.call_count == 1
     assert target.launch.call_count == 3
-    assert target.step.call_count == 3
     assert target.detect_failure.call_count == 3
     assert serve_path.call_count == 3
     assert load_target.call_count == 1
@@ -130,7 +129,7 @@ def test_main_02(mocker, tmp_path):
     serve_path.return_value = (None, ["test.html"])  # passed to mocked Target.detect_failure
     # setup Target
     load_target = mocker.patch("grizzly.replay.replay.load_target")
-    target = mocker.Mock(spec=Target, binary="bin", launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, binary="bin", launch_timeout=30)
     target.RESULT_NONE = Target.RESULT_NONE
     target.detect_failure.return_value = Target.RESULT_NONE
     load_target.return_value.return_value = target
@@ -207,7 +206,7 @@ def test_main_04(mocker, tmp_path):
     mocker.patch("grizzly.replay.replay.FuzzManagerReporter", autospec=True)
     mocker.patch("grizzly.replay.replay.Sapphire", autospec=True)
     mocker.patch("grizzly.replay.replay.TestCase", autospec=True)
-    target = mocker.Mock(spec=Target, launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, launch_timeout=30)
     load_target = mocker.patch("grizzly.replay.replay.load_target", autospec=True)
     load_target.return_value.return_value = target
     fake_tmp = (tmp_path / "grz_tmp")
@@ -241,7 +240,7 @@ def test_main_05(mocker, tmp_path):
     serve_path = mocker.patch("grizzly.replay.replay.Sapphire.serve_path", autospec=True)
     serve_path.return_value = (None, ["test.html"])  # passed to mocked Target.detect_failure
     # setup Target
-    target = mocker.Mock(spec=Target, binary="bin", launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, binary="bin", launch_timeout=30)
     target.RESULT_FAILURE = Target.RESULT_FAILURE
     target.detect_failure.return_value = Target.RESULT_FAILURE
     target.monitor.is_healthy.return_value = False

--- a/grizzly/replay/test_replay.py
+++ b/grizzly/replay/test_replay.py
@@ -41,7 +41,7 @@ def test_replay_02(mocker, tmp_path):
     mocker.patch("grizzly.replay.replay.grz_tmp", return_value=str(tmp_path))
     server = mocker.Mock(spec=Sapphire, port=0x1337)
     server.serve_path.return_value = (SERVED_ALL, ["index.html"])
-    target = mocker.Mock(spec=Target, closed=True, forced_close=True, launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, closed=True, launch_timeout=30, rl_reset=1)
     target.RESULT_NONE = Target.RESULT_NONE
     target.detect_failure.return_value = Target.RESULT_NONE
     with TestCase("index.html", "redirect.html", "test-adapter") as testcase:
@@ -420,7 +420,7 @@ def test_replay_15(mocker):
     mocker.patch("grizzly.common.runner.sleep", autospec=True)
     server = mocker.Mock(spec=Sapphire, port=0x1337)
     server.serve_path.return_value = (SERVED_ALL, ["index.html"])
-    target = mocker.Mock(spec=Target, closed=True, forced_close=True, launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, closed=True, launch_timeout=30, rl_reset=1)
     target.RESULT_NONE = Target.RESULT_NONE
     target.detect_failure.return_value = Target.RESULT_NONE
     testcases = [
@@ -439,7 +439,7 @@ def test_replay_16(mocker):
     """test ReplayManager.run() - multiple TestCases - no repro - with repeats"""
     server = mocker.Mock(spec=Sapphire, port=0x1337)
     server.serve_path.return_value = (SERVED_ALL, ["index.html"])
-    target = mocker.Mock(spec=Target, closed=True, forced_close=True, launch_timeout=30, rl_reset=100)
+    target = mocker.Mock(spec=Target, closed=True, launch_timeout=30, rl_reset=100)
     target.RESULT_NONE = Target.RESULT_NONE
     target.detect_failure.return_value = Target.RESULT_NONE
     testcases = [
@@ -496,7 +496,7 @@ def test_replay_18(mocker, tmp_path):
     mocker.patch("grizzly.replay.replay.grz_tmp", return_value=str(tmp_path))
     server = mocker.Mock(spec=Sapphire, port=0x1337)
     server.serve_path.return_value = (SERVED_ALL, ["index.html"])
-    target = mocker.Mock(spec=Target, closed=True, forced_close=True, launch_timeout=30, rl_reset=1)
+    target = mocker.Mock(spec=Target, closed=True, launch_timeout=30, rl_reset=1)
     target.RESULT_NONE = Target.RESULT_NONE
     target.detect_failure.return_value = Target.RESULT_NONE
     with TestCase("index.html", "redirect.html", "test-adapter") as testcase:

--- a/grizzly/session.py
+++ b/grizzly/session.py
@@ -143,7 +143,6 @@ class Session(object):
                         "/grz_harness",
                         self.server.port,
                         close_after=self.target.rl_reset,
-                        forced_close=self.target.forced_close,
                         timeout=self.adapter.TEST_DURATION)
                 runner.launch(location, max_retries=3, retry_delay=0)
             self.target.step()

--- a/grizzly/session.py
+++ b/grizzly/session.py
@@ -163,16 +163,9 @@ class Session(object):
                 log.debug("calling self.adapter.on_served()")
                 self.adapter.on_served(current_test, result.served)
             # update test case
-            if result.attempted:
-                if not result.served:
-                    # this can happen if the target crashes between serving test cases
-                    log.info("Ignoring test case since nothing was served")
-                    self.iomanager.tests.pop().cleanup()
-                elif self.adapter.IGNORE_UNSERVED:
-                    log.debug("removing unserved files from the test case")
-                    current_test.purge_optional(result.served)
-            else:
-                log.error("Test case was not served")
+            if not result.attempted:
+                log.debug("Ignoring test case since nothing was served")
+                self.iomanager.tests.pop().cleanup()
                 if not current_test.contains(current_test.landing_page):
                     log.warning("Test case is missing landing page")
                 if result.initial:
@@ -183,7 +176,10 @@ class Session(object):
                     log.error("ERROR: Test case was not served. Timeout too short?")
                     log.error("Logs can be found here %r", err_logs)
                     raise SessionError("Please check Adapter and Target")
-
+                log.warning("Test case was not served")
+            elif self.adapter.IGNORE_UNSERVED:
+                log.debug("removing unserved files from the test case")
+                current_test.purge_optional(result.served)
             # process results
             if result.status == RunResult.FAILED:
                 log.debug("result detected")

--- a/grizzly/target/__init__.py
+++ b/grizzly/target/__init__.py
@@ -14,8 +14,8 @@ __all__ = ("Target", "TargetError", "TargetLaunchError", "TargetLaunchTimeout",
 __author__ = "Tyson Smith"
 __credits__ = ["Tyson Smith", "Jesse Schwartzentruber"]
 
-TARGETS = None
 LOG = getLogger(__name__)
+TARGETS = dict()
 
 
 def _load_targets():
@@ -41,12 +41,12 @@ def _load_targets():
 
 
 def available():
-    if TARGETS is None:
+    if not TARGETS:
         _load_targets()
     return TARGETS.keys()
 
 
 def load(name):
-    if TARGETS is None:
+    if not TARGETS:
         _load_targets()
     return TARGETS[name]

--- a/grizzly/target/puppet_target.py
+++ b/grizzly/target/puppet_target.py
@@ -35,8 +35,8 @@ LOG = getLogger(__name__)
 class PuppetTarget(Target):
     __slots__ = ("use_rr", "use_valgrind", "_puppet", "_remove_prefs")
 
-    def __init__(self, binary, extension, launch_timeout, log_limit, memory_limit, relaunch, **kwds):
-        super().__init__(binary, extension, launch_timeout, log_limit, memory_limit, relaunch)
+    def __init__(self, binary, extension, launch_timeout, log_limit, memory_limit, **kwds):
+        super().__init__(binary, extension, launch_timeout, log_limit, memory_limit)
         self.use_rr = kwds.pop("rr", False)
         self.use_valgrind = kwds.pop("valgrind", False)
         self._remove_prefs = False
@@ -197,7 +197,6 @@ class PuppetTarget(Target):
             sleep(delay)
 
     def launch(self, location, env_mod=None):
-        self.rl_countdown = self.rl_reset
         # setup environment
         env_mod = dict(env_mod or [])
         # do not allow network connections to non local endpoints

--- a/grizzly/target/puppet_target.py
+++ b/grizzly/target/puppet_target.py
@@ -103,9 +103,6 @@ class PuppetTarget(Target):
 
     def detect_failure(self, ignored, was_timeout):
         status = self.RESULT_NONE
-        if self.expect_close and not was_timeout:
-            # give the browser a moment to close if needed
-            self._puppet.wait(timeout=30)
         is_healthy = self._puppet.is_healthy()
         # check if there has been a crash, hang, etc...
         if not is_healthy or was_timeout:

--- a/grizzly/target/target.py
+++ b/grizzly/target/target.py
@@ -53,6 +53,7 @@ class TargetLaunchTimeout(TargetError):
     """Raised if the target does not launch within the defined amount of time"""
 
 
+# TODO: remove forced_close, rl_countdown, rl_reset, relaunch, check_relaunch, expect_close
 class Target(metaclass=ABCMeta):
     RESULT_NONE = 0
     RESULT_FAILURE = 1

--- a/grizzly/target/target.py
+++ b/grizzly/target/target.py
@@ -53,14 +53,14 @@ class TargetLaunchTimeout(TargetError):
     """Raised if the target does not launch within the defined amount of time"""
 
 
-# TODO: remove forced_close, rl_countdown, rl_reset, relaunch, check_relaunch, expect_close
+# TODO: remove rl_countdown, rl_reset, relaunch, check_relaunch
 class Target(metaclass=ABCMeta):
     RESULT_NONE = 0
     RESULT_FAILURE = 1
     RESULT_IGNORED = 2
 
     __slots__ = (
-        "_lock", "_monitor", "_prefs", "binary", "extension", "forced_close",
+        "_lock", "_monitor", "_prefs", "binary", "extension",
         "launch_timeout", "log_limit", "memory_limit", "rl_countdown", "rl_reset")
 
     def __init__(self, binary, extension, launch_timeout, log_limit, memory_limit, relaunch):
@@ -73,7 +73,6 @@ class Target(metaclass=ABCMeta):
         self._prefs = None
         self.binary = binary
         self.extension = extension
-        self.forced_close = getenv("GRZ_FORCED_CLOSE") != "0"
         self.launch_timeout = max(launch_timeout, 300)
         self.log_limit = log_limit
         self.memory_limit = memory_limit
@@ -133,10 +132,6 @@ class Target(metaclass=ABCMeta):
     def dump_coverage(self):  # pylint: disable=no-self-use
         LOG.warning("dump_coverage() is not supported!")
 
-    @property
-    def expect_close(self):
-        # This is used to indicate if the browser will self close after the current iteration
-        return self.rl_countdown < 1 and not self.forced_close
 
     def is_idle(self, threshold):  # pylint: disable=no-self-use,unused-argument
         LOG.debug("Target.is_idle() not implemented! returning False")

--- a/grizzly/target/test_puppet_target.py
+++ b/grizzly/target/test_puppet_target.py
@@ -161,16 +161,6 @@ def test_puppet_target_03(mocker, tmp_path):
     fake_ffp.return_value.available_logs.return_value = " ffp_worker_log_size "
     assert target.detect_failure(["log-limit"], False) == Target.RESULT_IGNORED
     assert fake_ffp.return_value.close.call_count == 1
-    fake_ffp.reset_mock()
-    # test browser closing test case
-    fake_ffp.return_value.is_healthy.return_value = False
-    fake_ffp.return_value.is_running.return_value = False
-    fake_ffp.return_value.reason = FFPuppet.RC_EXITED
-    target.forced_close = False
-    target.rl_countdown = 0
-    assert target.detect_failure([], False) == Target.RESULT_NONE
-    assert fake_ffp.return_value.wait.call_count == 1
-    assert fake_ffp.return_value.close.call_count == 1
 
 @mark.skipif(system() == "Windows", reason="Unsupported on Windows")
 def test_puppet_target_04(mocker, tmp_path):

--- a/grizzly/target/test_puppet_target.py
+++ b/grizzly/target/test_puppet_target.py
@@ -19,7 +19,7 @@ def test_puppet_target_01(mocker, tmp_path):
     fake_ffp.return_value.log_length.return_value = 562
     fake_file = tmp_path / "fake"
     fake_file.touch()
-    with PuppetTarget(str(fake_file), None, 300, 25, 5000, 25) as target:
+    with PuppetTarget(str(fake_file), None, 300, 25, 5000) as target:
         assert target.closed
         assert not target._remove_prefs
         prefs_file = target.prefs
@@ -37,7 +37,7 @@ def test_puppet_target_01(mocker, tmp_path):
     assert fake_ffp.return_value.clean_up.call_count == 1
     assert not isfile(prefs_file)
     # with extra args
-    with PuppetTarget(str(fake_file), None, 1, 1, 1, 1, rr=True, fake=1) as target:
+    with PuppetTarget(str(fake_file), None, 1, 1, 1, rr=True, fake=1) as target:
         pass
 
 def test_puppet_target_02(mocker, tmp_path):
@@ -46,7 +46,7 @@ def test_puppet_target_02(mocker, tmp_path):
     fake_file = tmp_path / "fake"
     fake_file.touch()
     # test providing prefs.js
-    with PuppetTarget(str(fake_file), None, 300, 25, 5000, 35) as target:
+    with PuppetTarget(str(fake_file), None, 300, 25, 5000) as target:
         target.prefs = str(fake_file)
         assert not target._remove_prefs
         # launch success
@@ -79,7 +79,7 @@ def test_puppet_target_03(mocker, tmp_path):
     fake_ffp.RC_WORKER = FFPuppet.RC_WORKER
     fake_file = tmp_path / "fake"
     fake_file.touch()
-    target = PuppetTarget(str(fake_file), None, 300, 25, 5000, 25)
+    target = PuppetTarget(str(fake_file), None, 300, 25, 5000)
     # no failures
     fake_ffp.return_value.is_healthy.return_value = True
     fake_ffp.return_value.reason = None
@@ -173,10 +173,9 @@ def test_puppet_target_04(mocker, tmp_path):
     fake_time = mocker.patch("grizzly.target.puppet_target.time", autospec=True)
     fake_file = tmp_path / "fake"
     fake_file.touch()
-    target = PuppetTarget(str(fake_file), None, 300, 25, 5000, 10)
+    target = PuppetTarget(str(fake_file), None, 300, 25, 5000)
     fake_kill = mocker.patch("grizzly.target.puppet_target.kill", autospec=True)
     # not running
-    target.rl_countdown = 1
     fake_ffp.return_value.get_pid.return_value = None
     target.dump_coverage()
     assert not fake_kill.call_count
@@ -247,7 +246,7 @@ def test_puppet_target_05(mocker, tmp_path):
     fake_ffp.return_value.cpu_usage.return_value = [(999, 30), (998, 20), (997, 10)]
     fake_file = tmp_path / "fake"
     fake_file.touch()
-    with PuppetTarget(str(fake_file), None, 300, 25, 5000, 10) as target:
+    with PuppetTarget(str(fake_file), None, 300, 25, 5000) as target:
         assert not target.is_idle(0)
         assert not target.is_idle(25)
         assert target.is_idle(50)
@@ -257,7 +256,7 @@ def test_puppet_target_06(mocker, tmp_path):
     fake_ffp = mocker.patch("grizzly.target.puppet_target.FFPuppet", autospec=True)
     fake_file = tmp_path / "fake"
     fake_file.touch()
-    with PuppetTarget(str(fake_file), None, 300, 25, 5000, 25) as target:
+    with PuppetTarget(str(fake_file), None, 300, 25, 5000) as target:
         fake_ffp.return_value.is_running.return_value = False
         fake_ffp.return_value.is_healthy.return_value = False
         assert target.monitor is not None
@@ -279,7 +278,7 @@ def test_puppet_target_07(mocker, tmp_path):
     mocker.patch("grizzly.target.puppet_target.FFPuppet", autospec=True)
     fake_file = tmp_path / "fake"
     fake_file.touch()
-    with PuppetTarget(str(fake_file), None, 300, 25, 5000, 25) as target:
+    with PuppetTarget(str(fake_file), None, 300, 25, 5000) as target:
         # default temp prefs
         assert not target._remove_prefs
         prefs_file = target.prefs

--- a/grizzly/target/test_target.py
+++ b/grizzly/target/test_target.py
@@ -34,7 +34,6 @@ def test_target_01(tmp_path):
     target = SimpleTarget(str(fake_file), str(fake_file), 321, 2, 3, 25)
     assert target.binary == str(fake_file)
     assert target.extension == str(fake_file)
-    assert target.forced_close
     assert not target.is_idle(0)
     assert target.launch_timeout == 321
     assert target.log_size() == 0
@@ -42,27 +41,12 @@ def test_target_01(tmp_path):
     assert target.memory_limit == 3
     assert target.rl_countdown == 0
     assert target.rl_reset == 25
-    assert not target.expect_close
     # test stubs
     target.add_abort_token("none!")
     target.dump_coverage()
     target.reverse(1, 2)
 
 def test_target_02(mocker, tmp_path):
-    """test setting Target.forced_close"""
-    fake_file = tmp_path / "fake"
-    fake_file.touch()
-    getenv = mocker.patch("grizzly.target.target.getenv", autospec=True, return_value="0")
-    with SimpleTarget(str(fake_file), None, 300, 25, 5000, 25) as target:
-        assert not target.forced_close
-        assert target.extension is None
-        target.rl_countdown = 1
-        assert not target.expect_close
-        target.rl_countdown = 0
-        assert target.expect_close
-    getenv.assert_called_with("GRZ_FORCED_CLOSE")
-
-def test_target_03(mocker, tmp_path):
     """test Target.check_relaunch() and Target.step()"""
     fake_file = tmp_path / "fake"
     fake_file.touch()

--- a/grizzly/test_main.py
+++ b/grizzly/test_main.py
@@ -10,7 +10,7 @@ from sapphire import Sapphire
 from .common import Adapter, Report
 from .main import main
 from .session import Session
-from .target import TargetLaunchError
+from .target import Target, TargetLaunchError
 
 
 class FakeArgs(object):
@@ -27,7 +27,7 @@ class FakeArgs(object):
         self.log_level = 10  # 10 = DEBUG, 20 = INFO
         self.log_limit = 0
         self.memory = 0
-        self.platform = "test"
+        self.platform = "fake-target"
         self.prefs = None
         self.rr = False
         self.relaunch = 1000
@@ -47,8 +47,7 @@ def test_main_01(mocker):
     fake_adapter.RELAUNCH = 1
     fake_adapter.TEST_DURATION = 10
     mocker.patch("grizzly.main.get_adapter", return_value=lambda: fake_adapter)
-    targets = mocker.patch("grizzly.target.TARGETS")
-    targets.return_value = "fake-target"
+    mocker.patch.dict("grizzly.target.TARGETS", values={"fake-target": mocker.Mock(spec=Target)})
     fake_session = mocker.patch("grizzly.main.Session", autospec=True)
     fake_session.return_value.server = mocker.Mock(spec=Sapphire)
     fake_session.EXIT_SUCCESS = Session.EXIT_SUCCESS
@@ -58,19 +57,32 @@ def test_main_01(mocker):
     args.input = "fake"
     args.ignore = ["fake", "fake"]
     args.prefs = "fake"
-    args.rr = True
     args.valgrind = True
     args.xvfb = True
     with raises(RuntimeError, match="Coverage must be run with --relaunch > 1"):
         main(args)
-    fake_adapter.RELAUNCH = 0
+    fake_session.assert_not_called()
+    # successful run
+    fake_adapter.RELAUNCH = 1
+    args.coverage = False
     assert main(args) == Session.EXIT_SUCCESS
+    assert not fake_session.mock_calls[0][-1]["coverage"]
+    assert fake_session.mock_calls[0][-1]["relaunch"] == 1
+    fake_session.reset_mock()
+    # with FM
+    fake_adapter.RELAUNCH = 0
     fake_reporter = mocker.patch("grizzly.main.FuzzManagerReporter", autospec=True)
     fake_reporter.sanity_check.return_value = True
+    args.coverage = True
     args.input = None
     args.log_level = None
     args.fuzzmanager = True
+    args.rr = True
     assert main(args) == Session.EXIT_SUCCESS
+    assert fake_session.mock_calls[0][-1]["coverage"]
+    assert fake_session.mock_calls[0][-1]["relaunch"] == 1000
+    fake_session.reset_mock()
+    # with S3FM
     fake_reporter = mocker.patch("grizzly.main.S3FuzzManagerReporter", autospec=True)
     fake_reporter.sanity_check.return_value = True
     args.fuzzmanager = False
@@ -83,8 +95,7 @@ def test_main_02(mocker, tmp_path):
     fake_adapter.TEST_DURATION = 10
     fake_adapter.RELAUNCH = 0
     mocker.patch("grizzly.main.get_adapter", return_value=lambda: fake_adapter)
-    targets = mocker.patch("grizzly.target.TARGETS")
-    targets.return_value = "fake-target"
+    mocker.patch.dict("grizzly.target.TARGETS", values={"fake-target": mocker.Mock(spec=Target)})
     fake_session = mocker.patch("grizzly.main.Session", autospec=True)
     fake_session.EXIT_SUCCESS = Session.EXIT_SUCCESS
     fake_session.EXIT_ABORT = Session.EXIT_ABORT

--- a/sapphire/job.py
+++ b/sapphire/job.py
@@ -88,6 +88,10 @@ class Job(object):
                     "required" if resource.required else "optional",
                     redirect,
                     resource.target)
+            for dyn_resp, resource in self.server_map.dynamic.items():
+                if resource.required:
+                    self._pending.files.add(dyn_resp)
+                    LOG.debug("%s: %r -> %r", "required", dyn_resp, resource.target)
         self.initial_queue_size = len(self._pending.files)
         LOG.debug("%d files required to serve", self.initial_queue_size)
 

--- a/sapphire/server_map.py
+++ b/sapphire/server_map.py
@@ -53,7 +53,7 @@ class ServerMap(object):
             raise InvalidURLError("Only alpha-numeric characters accepted in URL.")
         return url
 
-    def set_dynamic_response(self, url, callback, mime_type="application/octet-stream"):
+    def set_dynamic_response(self, url, callback, mime_type="application/octet-stream", required=False):
         url = self._check_url(url)
         if not callable(callback):
             raise TypeError("callback must be callable")
@@ -65,7 +65,8 @@ class ServerMap(object):
         self.dynamic[url] = Resource(
             Resource.URL_DYNAMIC,
             callback,
-            mime=mime_type)
+            mime=mime_type,
+            required=required)
 
     def set_include(self, url, target_path):
         url = self._check_url(url)

--- a/sapphire/test_sapphire.py
+++ b/sapphire/test_sapphire.py
@@ -385,17 +385,13 @@ def test_sapphire_18(client, tmp_path):
     assert inc403.code == 403
 
 def test_sapphire_19(client, tmp_path):
-    """test dynamic response"""
-    _test_string = b"dynamic response -- TEST DATA!"
-
-    def _dyn_test_cb():
-        return _test_string
-
+    """test dynamic response - not required"""
+    _data = b"dynamic response -- TEST DATA!"
+    test_dr = _TestFile("dyn_test")
+    test_dr.len_org = len(_data)
+    test_dr.md5_org = hashlib.md5(_data).hexdigest()
     smap = ServerMap()
-    test_dr = _TestFile("dynm_test")
-    test_dr.len_org = len(_test_string)
-    test_dr.md5_org = hashlib.md5(_test_string).hexdigest()
-    smap.set_dynamic_response("dynm_test", _dyn_test_cb, mime_type="text/plain")
+    smap.set_dynamic_response("dyn_test", lambda: _data, mime_type="text/plain")
     test = _create_test("test_case.html", tmp_path)
     with Sapphire(timeout=10) as serv:
         client.launch("127.0.0.1", serv.port, [test_dr, test], in_order=True)
@@ -407,7 +403,23 @@ def test_sapphire_19(client, tmp_path):
     assert test_dr.len_srv == test_dr.len_org
     assert test_dr.md5_srv == test_dr.md5_org
 
-def test_sapphire_20(client_factory, tmp_path):
+def test_sapphire_20(client, tmp_path):
+    """test dynamic response - required"""
+    _data = b"dynamic response -- TEST DATA!"
+    test_dr = _TestFile("dyn_test")
+    test_dr.len_org = len(_data)
+    test_dr.md5_org = hashlib.md5(_data).hexdigest()
+    smap = ServerMap()
+    smap.set_dynamic_response("dyn_test", lambda: _data, mime_type="text/plain", required=True)
+    with Sapphire(timeout=10) as serv:
+        client.launch("127.0.0.1", serv.port, [test_dr], in_order=True)
+        assert serv.serve_path(str(tmp_path), server_map=smap)[0] == SERVED_ALL
+    assert client.wait(timeout=10)
+    assert test_dr.code == 200
+    assert test_dr.len_srv == test_dr.len_org
+    assert test_dr.md5_srv == test_dr.md5_org
+
+def test_sapphire_21(client_factory, tmp_path):
     """test pending_files == 0 in worker thread"""
     client_defer = client_factory(rx_size=2)
     # server should shutdown while this file is being served
@@ -426,7 +438,7 @@ def test_sapphire_20(client_factory, tmp_path):
     assert test.code == 200
     assert test_defer.code == 0
 
-def test_sapphire_21(client, tmp_path):
+def test_sapphire_22(client, tmp_path):
     """test handling an invalid request"""
     bad_test = _TestFile("bad.html")
     bad_test.custom_request = b"a bad request...0+%\xef\xb7\xba\r\n"
@@ -439,7 +451,7 @@ def test_sapphire_21(client, tmp_path):
     assert test.code == 200
     assert bad_test.code == 400
 
-def test_sapphire_22(client, tmp_path):
+def test_sapphire_23(client, tmp_path):
     """test handling an empty request"""
     bad_test = _TestFile("bad.html")
     bad_test.custom_request = b""
@@ -452,7 +464,7 @@ def test_sapphire_22(client, tmp_path):
     assert test.code == 200
     assert bad_test.code == 0
 
-def test_sapphire_23(client_factory, tmp_path):
+def test_sapphire_24(client_factory, tmp_path):
     """test requesting multiple files via multiple connections"""
     to_serve = list()
     for i in range(2):
@@ -478,7 +490,7 @@ def test_sapphire_23(client_factory, tmp_path):
         assert t_file.code == 200
         assert t_file.len_srv == t_file.len_org
 
-def test_sapphire_24(client_factory, tmp_path):
+def test_sapphire_25(client_factory, tmp_path):
     """test all request types via multiple connections"""
     def _dyn_test_cb():
         return b"A" if random.getrandbits(1) else b"AA"
@@ -509,7 +521,7 @@ def test_sapphire_24(client_factory, tmp_path):
             clients[-1].launch("127.0.0.1", serv.port, to_serve, throttle=throttle)
         assert serv.serve_path(str(tmp_path), server_map=smap)[0] == SERVED_ALL
 
-def test_sapphire_25(client, tmp_path):
+def test_sapphire_26(client, tmp_path):
     """test dynamic response with bad callbacks"""
     test_dr = _TestFile("dynm_test")
     smap = ServerMap()
@@ -520,7 +532,7 @@ def test_sapphire_25(client, tmp_path):
         with pytest.raises(TypeError):
             serv.serve_path(str(tmp_path), server_map=smap)
 
-def test_sapphire_26(client, tmp_path):
+def test_sapphire_27(client, tmp_path):
     """test serving to a slow client"""
     t_data = "".join(random.choice("ABCD1234") for _ in range(0x19000))  # 100KB
     t_file = _create_test("test_case.html", tmp_path, data=t_data.encode("ascii"), calc_hash=True)
@@ -536,7 +548,7 @@ def test_sapphire_26(client, tmp_path):
     assert t_file.len_srv == t_file.len_org
     assert t_file.md5_srv == t_file.md5_org
 
-def test_sapphire_27(client, tmp_path):
+def test_sapphire_28(client, tmp_path):
     """test timeout while requesting multiple files"""
     files_to_serve = list()
     t_data = "".join(random.choice("ABCD1234") for _ in range(1024)).encode("ascii")
@@ -549,7 +561,7 @@ def test_sapphire_27(client, tmp_path):
     assert status == SERVED_TIMEOUT
     assert len(files_served) < len(files_to_serve)
 
-def test_sapphire_28(client_factory, tmp_path):
+def test_sapphire_29(client_factory, tmp_path):
     """test Sapphire.serve_path() with forever=True"""
     clients = list()
     with Sapphire(timeout=10) as serv:
@@ -570,7 +582,7 @@ def test_sapphire_28(client_factory, tmp_path):
     assert test.code == 200
     assert test.len_srv == test.len_org
 
-def test_sapphire_29(client, tmp_path):
+def test_sapphire_30(client, tmp_path):
     """test interesting file names"""
     to_serve = [
         # space in file name
@@ -583,7 +595,7 @@ def test_sapphire_29(client, tmp_path):
     assert client.wait(timeout=10)
     assert all(t_file.code == 200 for t_file in to_serve)
 
-def test_sapphire_30(client, tmp_path):
+def test_sapphire_31(client, tmp_path):
     """test interesting path string"""
     all_bytes = "".join(chr(i) for i in range(256))
     to_serve = [
@@ -597,7 +609,7 @@ def test_sapphire_30(client, tmp_path):
     assert client.wait(timeout=10)
     assert all(t_file.code is not None for t_file in to_serve)
 
-def test_sapphire_31(mocker):
+def test_sapphire_32(mocker):
     """test Sapphire._create_listening_socket()"""
     fake_sleep = mocker.patch("sapphire.core.sleep", autospec=True)
     fake_sock = mocker.patch("sapphire.core.socket", autospec=True)
@@ -625,7 +637,7 @@ def test_sapphire_31(mocker):
     assert fake_sock.return_value.listen.call_count == 1
     assert fake_sleep.call_count == 1
 
-def test_sapphire_32(mocker):
+def test_sapphire_33(mocker):
     """test Sapphire.clear_backlog()"""
     mocker.patch("sapphire.core.socket", autospec=True)
     mocker.patch("sapphire.core.time", autospec=True, return_value=1)

--- a/sapphire/worker.py
+++ b/sapphire/worker.py
@@ -111,9 +111,9 @@ class Worker(object):
                 LOG.debug("resource is None")  # 404
             elif resource.type in (Resource.URL_FILE, Resource.URL_INCLUDE):
                 finish_job = serv_job.remove_pending(resource.target)
-            elif resource.type == Resource.URL_REDIRECT:
+            elif resource.type in (Resource.URL_DYNAMIC, Resource.URL_REDIRECT):
                 finish_job = serv_job.remove_pending(request)
-            elif resource.type != Resource.URL_DYNAMIC:  # pragma: no cover
+            else:  # pragma: no cover
                 # this should never happen
                 raise WorkerError("Unknown resource type %r" % (resource.type,))
 
@@ -155,7 +155,7 @@ class Worker(object):
                     raise TypeError("dynamic request callback must return 'bytes'")
                 conn.sendall(cls._200_header(len(data), resource.mime))
                 conn.sendall(data)
-                LOG.debug("200 %r (dynamic request)", request)
+                LOG.debug("200 %r - dynamic request (%d to go)", request, serv_job.pending)
                 return
 
             # at this point we know "resource.target" maps to a file on disk


### PR DESCRIPTION
This moves the relaunch logic into Runner from multiple locations. We will now always assume the process is going to exit cleanly on its own. This also means we should no longer require a special case for LSan. It does have the side-effect of a delay (2 seconds atm) before closing the process on systems where the process does not terminate when the last window is closed.

This also makes replay (and reduce) much more reliable when crashes are slightly delayed.