### PR TITLE
Reconfigure linters.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,22 @@
 repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.1
+    hooks:
+      - id: isort
   - repo: https://github.com/asottile/yesqa
-    rev: v1.2.2
+    rev: v1.2.3
     hooks:
       - id: yesqa
+  - repo: https://github.com/ambv/black
+    rev: 21.6b0
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -19,6 +31,11 @@ repos:
         args: ['--django']
       - id: check-json
       - id: requirements-txt-fixer
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        exclude_types: [json]
   - repo: https://github.com/marco-c/taskcluster_yml_validator
     rev: v0.0.7
     hooks:
@@ -32,11 +49,11 @@ repos:
       - id: check-useless-excludes
   - repo: local
     hooks:
-      - id: lint
-        name: Run linters
-        entry: tox -e lint
+      - id: pylint
+        name: pylint
+        entry: tox -e pylint --
         language: system
-        pass_filenames: false
+        require_serial: true
         types: [python]
 
 default_language_version:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -75,12 +75,6 @@ tasks:
               TOXENV: lint
             script:
               - tox
-          - name: precommit
-            version: "3.9"
-            env:
-              TOXENV: precommit
-            script:
-              - tox
           - name: PyPI upload
             version: "3.8"
             env:

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,3 +65,6 @@ dev =
     tox
 s3 =
     boto3
+
+[codespell]
+ignore-regex = \\[fnrstv]

--- a/tox.ini
+++ b/tox.ini
@@ -31,32 +31,17 @@ deps =
     coverage[toml]
 skip_install = true
 
-[testenv:precommit]
+[testenv:lint]
 commands =
-    pre-commit run -a
+    pre-commit run -a {posargs}
 deps =
     pre-commit
 skip_install = true
 
-[testenv:lint]
-allowlist_externals =
-    bash
+[testenv:pylint]
 commands =
-    isort --check-only {toxinidir}
-    black --check {toxinidir}
-    # codespell trips over the regex in 'sapphire/worker.py' saying 'sHTTP ==> https'
-    # https://github.com/codespell-project/codespell/issues/1774
-    # ignoring it is broken so we need to ignore the file
-    codespell --skip=".git,.tox,htmlcov,results,./sapphire/worker.py" {toxinidir}
-    pylint {toxinidir}/grizzly
-    pylint {toxinidir}/loki
-    pylint {toxinidir}/sapphire
-    flake8 {toxinidir}
+    pylint {posargs}
 deps =
-    black
-    codespell
-    flake8
-    isort
     pylint==2.8.3
 usedevelop = true
 


### PR DESCRIPTION
Allow pre-commit to control all versions except pylint, which is configured in a toxenv to allow dependencies to be installed.