### PR TITLE
Simplify TestCase and TestFile implementations

### DIFF
--- a/grizzly/adapter/no_op_adapter/__init__.py
+++ b/grizzly/adapter/no_op_adapter/__init__.py
@@ -30,12 +30,12 @@ class NoOpAdapter(Adapter):
         """
         self.enable_harness()
         self.fuzz["test"] = (
-            "<!DOCTYPE html>\n"
-            "<html>\n"
-            "<head>\n"
-            "<script>window.close()</script>\n"
-            "</head>\n"
-            "</html>"
+            b"<!DOCTYPE html>\n"
+            b"<html>\n"
+            b"<head>\n"
+            b"<script>window.close()</script>\n"
+            b"</head>\n"
+            b"</html>"
         )
 
     def generate(self, testcase, _server_map):
@@ -53,4 +53,4 @@ class NoOpAdapter(Adapter):
         Returns:
             None
         """
-        testcase.add_from_data(self.fuzz["test"], testcase.landing_page)
+        testcase.add_from_bytes(self.fuzz["test"], testcase.landing_page)

--- a/grizzly/adapter/no_op_adapter/test_no_op.py
+++ b/grizzly/adapter/no_op_adapter/test_no_op.py
@@ -14,6 +14,6 @@ def test_no_op_01():
     adapter.setup(None, None)
     test = TestCase("a", "b", adapter.name)
     assert not test.data_size
-    assert not test.contains("a")
+    assert "a" not in test.contents
     adapter.generate(test, None)
-    assert test.contains("a")
+    assert "a" in test.contents

--- a/grizzly/common/storage.py
+++ b/grizzly/common/storage.py
@@ -343,9 +343,12 @@ class TestCase:
             elif path.is_dir():
                 tests = list()
                 assets = None
-                # TODO: move (don't copy) 'unpacked' files
                 for tc_path in TestCase.scan_path(path):
-                    tests.append(cls.load_single(tc_path, load_assets=assets is None))
+                    tests.append(
+                        cls.load_single(
+                            tc_path, load_assets=assets is None, copy=unpacked is None
+                        )
+                    )
                     # only load assets once
                     if not assets and tests[-1].assets:
                         assets = tests[-1].assets
@@ -363,7 +366,7 @@ class TestCase:
         return tests
 
     @classmethod
-    def load_single(cls, path, adjacent=False, load_assets=True):
+    def load_single(cls, path, adjacent=False, load_assets=True, copy=True):
         """Load contents of a TestCase from disk. If `path` is a directory it must
         contain a valid 'test_info.json' file.
 
@@ -372,6 +375,8 @@ class TestCase:
             adjacent (bool): Load adjacent files as part of the TestCase.
                              This is always true when loading a directory.
                              WARNING: This should be used with caution!
+            load_assets (bool): Load assets files.
+            copy (bool): Files will be copied if True otherwise the they will be moved.
 
         Returns:
             TestCase: A TestCase.
@@ -412,7 +417,7 @@ class TestCase:
         test.duration = info.get("duration", None)
         test.hang = info.get("hang", False)
         test.add_from_file(
-            entry_point, file_name=test.landing_page, required=True, copy=True
+            entry_point, file_name=test.landing_page, required=True, copy=copy
         )
         if info:
             # load assets
@@ -453,7 +458,7 @@ class TestCase:
                         file,
                         file_name=location,
                         required=False,
-                        copy=True,
+                        copy=copy,
                     )
         return test
 

--- a/grizzly/common/storage.py
+++ b/grizzly/common/storage.py
@@ -110,7 +110,7 @@ class TestCase:
                 relative = prefix / relative
             self.add_from_file(file, file_name=relative.as_posix(), copy=copy)
 
-    def add_from_bytes(self, data, file_name, required=True):
+    def add_from_bytes(self, data, file_name, required=False):
         """Create a file and add it to the TestCase.
 
         Args:
@@ -136,7 +136,7 @@ class TestCase:
             if data_file.is_file():
                 data_file.unlink()
 
-    def add_from_file(self, src_file, file_name=None, required=True, copy=False):
+    def add_from_file(self, src_file, file_name=None, required=False, copy=False):
         """Add a file to the TestCase by either copying or moving an existing file.
 
         Args:
@@ -165,7 +165,6 @@ class TestCase:
         else:
             move(src_file, test_file.data_file)
 
-        # TODO: set 'required=False' by default
         # landing_page is always 'required'
         if required or test_file.file_name == self.landing_page:
             self._files.required.append(test_file)
@@ -457,6 +456,8 @@ class TestCase:
                     # ignore files that have been previously loaded
                     if location in (test.landing_page, "test_info.json"):
                         continue
+                    # NOTE: when loading all files except the entry point are
+                    # marked as `required=False`
                     test.add_from_file(
                         file,
                         file_name=location,

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # pylint: disable=protected-access
 from itertools import count
-from os.path import join as pathjoin
 
 from pytest import mark, raises
 
@@ -338,9 +337,9 @@ def test_runner_10(mocker, tmp_path):
         result = runner.run([], smap, tcase)
         assert result.attempted
         assert result.status == Result.NONE
-        assert "inc_file.bin" in tcase._existing_paths
-        assert pathjoin("nested", "nested_inc.bin") in tcase._existing_paths
-        assert pathjoin("test", "inc_file3.txt") in tcase._existing_paths
+        assert "inc_file.bin" in tcase.contents
+        assert "nested/nested_inc.bin" in tcase.contents
+        assert "test/inc_file3.txt" in tcase.contents
 
 
 def test_idle_check_01(mocker):

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -15,7 +15,7 @@ from .runner import Runner, _IdleChecker
 from .storage import TestCase
 
 
-def test_runner_01(mocker, tmp_path):
+def test_runner_01(mocker):
     """test Runner()"""
     mocker.patch("grizzly.common.runner.time", autospec=True, side_effect=count())
     server = mocker.Mock(spec_set=Sapphire)
@@ -42,7 +42,6 @@ def test_runner_01(mocker, tmp_path):
     assert target.close.call_count == 0
     assert target.dump_coverage.call_count == 0
     assert target.handle_hang.call_count == 0
-    assert testcase.dump.call_count == 1
     # dump coverage
     serv_map = ServerMap()
     server.serve_path.return_value = (Served.ALL, serv_files)
@@ -57,21 +56,6 @@ def test_runner_01(mocker, tmp_path):
     assert target.close.call_count == 0
     assert target.dump_coverage.call_count == 1
     assert target.handle_hang.call_count == 0
-    # existing test path
-    testcase.reset_mock()
-    tc_path = tmp_path / "tc"
-    tc_path.mkdir()
-    serv_map = ServerMap()
-    server.serve_path.return_value = (Served.ALL, serv_files)
-    result = runner.run([], serv_map, testcase, test_path=str(tc_path))
-    assert result.attempted
-    assert runner._tests_run == 3
-    assert not result.initial
-    assert result.status == Result.NONE
-    assert not serv_map.dynamic
-    assert target.close.call_count == 0
-    assert testcase.dump.call_count == 0
-    tc_path.is_dir()
 
 
 def test_runner_02(mocker):

--- a/grizzly/common/test_storage.py
+++ b/grizzly/common/test_storage.py
@@ -30,10 +30,10 @@ def test_testcase_01(tmp_path):
         assert tcase.input_fname is None
         assert tcase.timestamp > 0
         assert not tcase.env_vars
-        assert not tcase._existing_paths
+        assert tcase.data_path
         assert not tcase._files.optional
         assert not tcase._files.required
-        assert not tcase.contains("no_file")
+        assert not any(tcase.contents)
         assert tcase.pop_assets() is None
         assert not any(tcase.optional)
         tcase.dump(str(tmp_path))
@@ -42,48 +42,68 @@ def test_testcase_01(tmp_path):
         assert (tmp_path / "test_info.json").is_file()
 
 
-def test_testcase_02(tmp_path):
-    """test TestCase with TestFiles"""
+@mark.parametrize(
+    "copy, required",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+)
+def test_testcase_02(tmp_path, copy, required):
+    """test TestCase.add_from_file()"""
     with TestCase("land_page.html", "a.html", "adpt", input_fname="in.bin") as tcase:
-        in_file = tmp_path / "testfile1.bin"
-        in_file.write_bytes(b"test_req")
-        tcase.add_from_file(str(in_file))
-        assert tcase.data_size == 8
-        with raises(TestFileExists, match="'testfile1.bin' exists in test"):
-            tcase.add_from_file(str(in_file), file_name="testfile1.bin")
-        with raises(TestFileExists, match="'testfile1.bin' exists in test"):
-            tcase.add_from_data("test", "testfile1.bin")
-        tcase.add_from_data("test_nreq", "nested/testfile2.bin", required=False)
-        tcase.add_from_data("test_blah", "/testfile3.bin")
-        tcase.add_from_data("test_windows", "\\\\dir\\file.bin")
-        assert tcase.contains("testfile1.bin")
-        opt_files = list(tcase.optional)
-        assert os.path.join("nested", "testfile2.bin") in opt_files
-        assert len(opt_files) == 1
-        tcase.dump(str(tmp_path), include_details=True)
-        assert (tmp_path / "nested").is_dir()
-        test_info = loads((tmp_path / "test_info.json").read_text())
-        assert test_info["adapter"] == "adpt"
-        assert test_info["input"] == "in.bin"
-        assert test_info["target"] == "land_page.html"
-        assert isinstance(test_info["env"], dict)
-        assert in_file.read_bytes() == b"test_req"
-        assert (tmp_path / "nested" / "testfile2.bin").read_bytes() == b"test_nreq"
-        assert (tmp_path / "testfile3.bin").read_bytes() == b"test_blah"
-        assert (tmp_path / "dir" / "file.bin").read_bytes() == b"test_windows"
-        tcase.cleanup()
+        in_file = tmp_path / "file.bin"
+        in_file.write_text("data")
+        tcase.add_from_file(str(in_file), copy=copy, required=required)
+        assert tcase.data_size == 4
+        assert "file.bin" in tcase.contents
+        if required:
+            assert in_file.name not in tcase.optional
+        else:
+            assert in_file.name in tcase.optional
+        assert in_file.exists() == copy
+        # try overwriting existing file
+        if copy:
+            with raises(TestFileExists, match="'file.bin' exists in test"):
+                tcase.add_from_file(str(in_file), copy=True)
+            assert in_file.exists()
+        else:
+            assert not in_file.exists()
 
 
-def test_testcase_03():
+@mark.parametrize(
+    "file_paths",
+    [
+        ("a.bin",),
+        ("a/a.bin",),
+        ("a.bin", "b.bin"),
+        ("a.bin", "b/c.bin", "b/d.bin"),
+    ],
+)
+def test_testcase_03(tmp_path, file_paths):
+    """test TestCase.add_from_file()"""
+    with TestCase("land_page.html", "a.html", "adpt") as tcase:
+        for file_path in file_paths:
+            src_file = tmp_path / file_path
+            src_file.parent.mkdir(exist_ok=True, parents=True)
+            src_file.write_text("data")
+            tcase.add_from_file(str(src_file), file_name=file_path, required=True)
+            assert file_path in tcase.contents
+            assert file_path not in tcase.optional
+
+
+def test_testcase_04():
     """test TestCase.purge_optional()"""
     with TestCase("land_page.html", "redirect.html", "test-adapter") as tcase:
         # no optional files
         tcase.purge_optional(["foo"])
         # setup
-        tcase.add_from_data("foo", "testfile1.bin")
-        tcase.add_from_data("foo", "testfile2.bin", required=False)
-        tcase.add_from_data("foo", "testfile3.bin", required=False)
-        tcase.add_from_data("foo", "not_served.bin", required=False)
+        tcase.add_from_bytes(b"foo", "testfile1.bin")
+        tcase.add_from_bytes(b"foo", "testfile2.bin", required=False)
+        tcase.add_from_bytes(b"foo", "testfile3.bin", required=False)
+        tcase.add_from_bytes(b"foo", "not_served.bin", required=False)
         assert len(tuple(tcase.optional)) == 3
         # nothing to remove - with required
         tcase.purge_optional(chain(["testfile1.bin"], tcase.optional))
@@ -102,17 +122,17 @@ def test_testcase_03():
         assert not any(tcase.optional)
 
 
-def test_testcase_04():
+def test_testcase_05():
     """test TestCase.data_size"""
     with TestCase("land_page.html", "redirect.html", "test-adapter") as tcase:
         assert tcase.data_size == 0
-        tcase.add_from_data("1", "testfile1.bin", required=True)
+        tcase.add_from_bytes(b"1", "testfile1.bin", required=True)
         assert tcase.data_size == 1
-        tcase.add_from_data("12", "testfile2.bin", required=False)
+        tcase.add_from_bytes(b"12", "testfile2.bin", required=False)
         assert tcase.data_size == 3
 
 
-def test_testcase_05(tmp_path):
+def test_testcase_06(tmp_path):
     """test TestCase.load_single() using a directory - fail cases"""
     # missing test_info.json
     with raises(TestCaseLoadFailure, match="Missing 'test_info.json'"):
@@ -154,7 +174,7 @@ def test_testcase_05(tmp_path):
         TestCase.load_single(str(src_dir))
 
 
-def test_testcase_06(mocker, tmp_path):
+def test_testcase_07(mocker, tmp_path):
     """test TestCase.load_single() using a directory"""
     # build a valid test case
     src_dir = tmp_path / "src"
@@ -195,9 +215,7 @@ def test_testcase_06(mocker, tmp_path):
         assert "target.bin" in (x.file_name for x in dst._files.required)
         assert "optional.bin" in (x.file_name for x in dst._files.optional)
         assert "x.bin" in (x.file_name for x in dst._files.optional)
-        assert os.path.join("nested", "x.bin") in (
-            x.file_name for x in dst._files.optional
-        )
+        assert "nested/x.bin" in (x.file_name for x in dst._files.optional)
         assert dst.env_vars["TEST_ENV_VAR"] == "100"
         assert dst.timestamp > 0
     # test load with missing asset
@@ -206,7 +224,7 @@ def test_testcase_06(mocker, tmp_path):
         TestCase.load_single(str(dst_dir))
 
 
-def test_testcase_07(tmp_path):
+def test_testcase_08(tmp_path):
     """test TestCase.load_single() using a file"""
     # invalid entry_point specified
     with raises(TestCaseLoadFailure, match="Missing or invalid TestCase"):
@@ -232,7 +250,7 @@ def test_testcase_07(tmp_path):
         assert "optional.bin" in (x.file_name for x in tcase._files.optional)
 
 
-def test_testcase_08(tmp_path):
+def test_testcase_09(tmp_path):
     """test TestCase - dump, load and compare"""
     working = tmp_path / "working"
     working.mkdir()
@@ -243,7 +261,7 @@ def test_testcase_08(tmp_path):
         org.hang = True
         org.input_fname = "infile"
         org.time_limit = 10
-        org.add_from_data("a", "a.html")
+        org.add_from_bytes(b"a", "a.html")
         with AssetManager(base_path=str(tmp_path)) as assets:
             fake = tmp_path / "fake_asset"
             fake.touch()
@@ -251,21 +269,21 @@ def test_testcase_08(tmp_path):
             org.assets = assets
             org.dump(str(working), include_details=True)
         org.assets = None
-        loaded = TestCase.load_single(str(working), adjacent=False)
-        try:
-            for prop in TestCase.__slots__:
-                if prop.startswith("_") or prop in ("assets", "redirect_page"):
-                    continue
-                assert getattr(loaded, prop) == getattr(org, prop)
-            assert org._existing_paths == loaded._existing_paths
-            assert loaded.assets
-            assert "fake" in loaded.assets.assets
-        finally:
-            if loaded.assets:
-                loaded.assets.cleanup()
+        with TestCase.load_single(str(working), adjacent=False) as loaded:
+            try:
+                for prop in TestCase.__slots__:
+                    if prop.startswith("_") or prop in ("assets", "redirect_page"):
+                        continue
+                    assert getattr(loaded, prop) == getattr(org, prop)
+                assert not set(org.contents) ^ set(loaded.contents)
+                assert loaded.assets
+                assert "fake" in loaded.assets.assets
+            finally:
+                if loaded.assets:
+                    loaded.assets.cleanup()
 
 
-def test_testcase_09(tmp_path):
+def test_testcase_10(tmp_path):
     """test TestCase.load() - missing file and empty directory"""
     # missing file
     with raises(TestCaseLoadFailure, match="Invalid TestCase path"):
@@ -274,7 +292,7 @@ def test_testcase_09(tmp_path):
     assert not TestCase.load(str(tmp_path), adjacent=True)
 
 
-def test_testcase_10(tmp_path):
+def test_testcase_11(tmp_path):
     """test TestCase.load() - single file"""
     tfile = tmp_path / "testcase.html"
     tfile.touch()
@@ -283,23 +301,23 @@ def test_testcase_10(tmp_path):
         assert len(testcases) == 1
         assert all(x.assets is None for x in testcases)
     finally:
-        map(lambda x: x.cleanup, testcases)
+        any(x.cleanup() for x in testcases)
 
 
-def test_testcase_11(tmp_path):
+def test_testcase_12(tmp_path):
     """test TestCase.load() - single directory"""
     with TestCase("target.bin", None, "test-adapter") as src:
-        src.add_from_data("test", "target.bin")
+        src.add_from_bytes(b"test", "target.bin")
         src.dump(str(tmp_path), include_details=True)
     testcases = TestCase.load(str(tmp_path))
     try:
         assert len(testcases) == 1
         assert all(x.assets is None for x in testcases)
     finally:
-        map(lambda x: x.cleanup, testcases)
+        any(x.cleanup() for x in testcases)
 
 
-def test_testcase_12(tmp_path):
+def test_testcase_13(tmp_path):
     """test TestCase.load() - multiple directories (with assets)"""
     nested = tmp_path / "nested"
     nested.mkdir()
@@ -309,7 +327,7 @@ def test_testcase_12(tmp_path):
         assets.add("example", str(asset_file))
         with TestCase("target.bin", None, "test-adapter") as src:
             src.assets = assets
-            src.add_from_data("test", "target.bin")
+            src.add_from_bytes(b"test", "target.bin")
             src.dump(str(nested / "test-1"), include_details=True)
             src.dump(str(nested / "test-2"), include_details=True)
             src.dump(str(nested / "test-3"), include_details=True)
@@ -321,6 +339,7 @@ def test_testcase_12(tmp_path):
         assert asset is not None
         assert "example" in asset.assets
     finally:
+        any(x.cleanup() for x in testcases)
         for test in testcases:
             if test.assets:
                 test.cleanup()
@@ -328,7 +347,7 @@ def test_testcase_12(tmp_path):
     assert not TestCase.load(str(tmp_path))
 
 
-def test_testcase_13(tmp_path):
+def test_testcase_14(tmp_path):
     """test TestCase.load() - archive"""
     archive = tmp_path / "testcase.zip"
     # bad archive
@@ -337,7 +356,7 @@ def test_testcase_13(tmp_path):
         TestCase.load(str(archive))
     # build archive containing multiple testcases
     with TestCase("target.bin", None, "test-adapter") as src:
-        src.add_from_data("test", "target.bin")
+        src.add_from_bytes(b"test", "target.bin")
         src.dump(str(tmp_path / "test-0"), include_details=True)
         src.dump(str(tmp_path / "test-1"), include_details=True)
         src.dump(str(tmp_path / "test-2"), include_details=True)
@@ -358,10 +377,10 @@ def test_testcase_13(tmp_path):
         assert len(testcases) == 3
         assert all(x.assets is None for x in testcases)
     finally:
-        map(lambda x: x.cleanup, testcases)
+        any(x.cleanup() for x in testcases)
 
 
-def test_testcase_14(tmp_path):
+def test_testcase_15(tmp_path):
     """test TestCase.add_batch()"""
     include = tmp_path / "inc_path"
     include.mkdir()
@@ -376,32 +395,32 @@ def test_testcase_14(tmp_path):
     with TestCase("a.b", "a.b", "simple") as tcase:
         # missing directory
         tcase.add_batch("/missing/path/", tuple())
-        assert not tcase._existing_paths
+        assert not any(tcase.contents)
         # missing file
         with raises(IOError):
             tcase.add_batch(str(tmp_path), [str(tmp_path / "missing.bin")])
-        assert not tcase._existing_paths
+        assert not any(tcase.contents)
         # relative file name
         tcase.add_batch(str(include), ["file.bin"])
-        assert not tcase._existing_paths
+        assert not any(tcase.contents)
         # valid list
         tcase.add_batch(
             str(include),
             [str(inc_1), str(inc_2), str(tmp_path / "inc_path2" / "extra.bin")],
         )
-        assert tcase.contains("file.bin")
-        assert tcase.contains(os.path.join("nested", "nested.js"))
-        assert len(tcase._existing_paths) == 2
+        assert "file.bin" in tcase.contents
+        assert "nested/nested.js" in tcase.contents
+        assert len(list(tcase.contents)) == 2
         # nested url
         tcase.add_batch(str(include), [str(inc_1)], prefix="test")
-        assert tcase.contains(os.path.join("test", "file.bin"))
-        assert len(tcase._existing_paths) == 3
+        assert "test/file.bin" in tcase.contents
+        assert len(list(tcase.contents)) == 3
         # collision
         with raises(TestFileExists, match="'file.bin' exists in test"):
             tcase.add_batch(str(include), [str(inc_1)])
 
 
-def test_testcase_15(tmp_path):
+def test_testcase_16(tmp_path):
     """test TestCase.scan_path()"""
     # empty path
     (tmp_path / "not-test").mkdir()
@@ -409,7 +428,7 @@ def test_testcase_15(tmp_path):
     # multiple test case directories
     paths = [str(tmp_path / ("test-%d" % i)) for i in range(3)]
     with TestCase("test.htm", None, "test-adapter") as src:
-        src.add_from_data("test", "test.htm")
+        src.add_from_bytes(b"test", "test.htm")
         for path in paths:
             src.dump(path, include_details=True)
     tc_paths = list(TestCase.scan_path(str(tmp_path)))
@@ -419,162 +438,105 @@ def test_testcase_15(tmp_path):
     assert len(tc_paths) == 1
 
 
-def test_testcase_16():
+def test_testcase_17():
     """test TestCase.get_file()"""
     with TestCase("test.htm", None, "test-adapter") as src:
-        src.add_from_data("test", "test.htm")
+        src.add_from_bytes(b"test", "test.htm")
         assert src.get_file("missing") is None
-        assert src.get_file("test.htm").data == b"test"
+        assert src.get_file("test.htm")
 
 
-def test_testcase_17():
+def test_testcase_18():
     """test TestCase.clone()"""
     with TestCase("a.htm", "b.htm", "adpt", input_fname="fn", time_limit=2) as src:
         src.duration = 1.2
         src.hang = True
-        src.add_from_data("123", "test.htm")
-        src.add_from_data("456", "opt.htm", required=False)
+        src.add_from_bytes(b"123", "test.htm")
+        src.add_from_bytes(b"456", "opt.htm", required=False)
         src.env_vars["foo"] = "bar"
-        with src.clone() as tgt:
+        with src.clone() as dst:
             for prop in TestCase.__slots__:
                 if prop.startswith("_"):
                     continue
-                assert getattr(src, prop) == getattr(tgt, prop)
-            assert src.data_size == tgt.data_size
+                assert getattr(src, prop) == getattr(dst, prop)
+            assert src.data_size == dst.data_size
             for file, data in (
                 ("test.htm", b"123"),
                 ("opt.htm", b"456"),
             ):
-                src.get_file(file).write(b"src")
-                tgt.get_file(file).write(b"tgt")
-                assert src.get_file(file).data == data + b"src"
-                assert tgt.get_file(file).data == data + b"tgt"
-            assert tgt.env_vars == {"foo": "bar"}
+                assert src.get_file(file).data_file.read_bytes() == data
+                assert dst.get_file(file).data_file.read_bytes() == data
+            assert dst.env_vars == {"foo": "bar"}
+            assert not set(src.optional) ^ set(dst.optional)
 
 
-def test_testfile_01():
+def test_testfile_01(tmp_path):
     """test simple TestFile"""
-    with TestFile("test_file.txt") as tfile:
-        assert tfile.file_name == "test_file.txt"
-        assert not tfile._fp.closed
-        assert tfile.size == 0
-        tfile.close()
-        assert tfile._fp.closed
+    data_file = tmp_path / "file.txt"
+    data_file.write_text("test")
+    with TestFile(data_file.name, tmp_path) as tfile:
+        assert tfile.file_name == "file.txt"
+    assert not data_file.exists()
 
 
-def test_testfile_02():
-    """test TestFile file names"""
-    # empty file name
-    with raises(TypeError, match="file_name is invalid"):
-        TestFile("")
-    # path (root) with missing file name
-    with raises(TypeError, match="file_name is invalid"):
-        TestFile("/")
-    # path (root) with missing file name
-    with raises(TypeError, match="file_name is invalid"):
-        TestFile("/.")
-    # path with missing file name
-    with raises(TypeError, match="file_name is invalid"):
-        TestFile("path/")
-    # invalid use of '..'
-    with raises(TypeError, match="file_name is invalid"):
-        TestFile("../test")
-    # path (root) with file
-    with TestFile("/valid.txt") as tfile:
-        assert tfile.file_name == "valid.txt"
-    # path with file
-    with TestFile("path\\file") as tfile:
-        assert os.path.split(tfile.file_name) == ("path", "file")
-    # with valid use of '.' and '..'
-    with TestFile("./a/./b/../c") as tfile:
-        assert os.path.split(tfile.file_name) == ("a", "c")
-    # filename starting with '.'
-    with TestFile(".file") as tfile:
-        assert tfile.file_name == ".file"
-
-
-def test_testfile_03(tmp_path):
-    """test TestFile.write() and TestFile.dump()"""
-    out_file = tmp_path / "test_file.txt"
-    with TestFile(out_file.name) as tfile:
-        tfile.write(b"foo")
-        assert not out_file.is_file()
-        tfile.dump(str(tmp_path))
-        assert out_file.is_file()
-        assert out_file.read_text() == "foo"
-        tfile.write(b"bar")
-        tfile.dump(str(tmp_path))
-        assert out_file.read_text() == "foobar"
-
-
-def test_testfile_04(tmp_path):
-    """test TestFile.dump() file with nested path"""
-    file_path = "test/dir/path/file.txt"
-    with TestFile(file_path) as tfile:
-        out_file = tmp_path / file_path
-        tfile.write(b"foo")
-        assert not out_file.is_file()
-        tfile.dump(str(tmp_path))
-        assert out_file.is_file()
+def test_testfile_02(tmp_path):
+    """test TestFile.copy_file()"""
+    src_file = tmp_path / "src" / "file.txt"
+    src_file.parent.mkdir(parents=True)
+    src_file.write_bytes(b"test\n123\r\n")
+    dst_path = tmp_path / "dst"
+    dst_file = dst_path / "file.txt"
+    assert not dst_file.is_file()
+    TestFile.copy_file(src_file, dst_file)
+    assert dst_file.is_file()
+    assert dst_file.read_bytes() == b"test\n123\r\n"
+    assert src_file.exists()
 
 
 @mark.parametrize(
-    "in_data, out_data",
+    "path",
     [
-        # data as string
-        ("foo", "foo"),
-        # data as binary
-        (b"foo", "foo"),
+        # empty file name
+        "",
+        # path (root) with missing file name
+        "/",
+        # path (root) with missing file name
+        "/.",
+        # path with missing file name
+        "path/",
+        # outside of wwwroot
+        "../test",
+        # outside of wwwroot
+        "a/../../b",
+        # outside of wwwroot
+        "..",
+        # outside of wwwroot
+        "C:\\test",
+        # cwd
+        ".",
     ],
 )
-def test_testfile_05(tmp_path, in_data, out_data):
-    """test TestFile.from_data()"""
-    with TestFile.from_data(in_data, "test_file.txt") as tfile:
-        tfile.dump(str(tmp_path))
-        out_file = tmp_path / "test_file.txt"
-        assert out_file.is_file()
-        assert out_file.read_text() == out_data
+def test_testfile_03(path):
+    """test TestCase.sanitize_path() with invalid paths"""
+    with raises(ValueError, match="invalid path"):
+        TestFile.sanitize_path(path)
 
 
-def test_testfile_06(tmp_path):
-    """test TestFile.from_file()"""
-    in_file = tmp_path / "infile.txt"
-    in_file.write_bytes(b"foobar")
-    # check re-using filename
-    with TestFile.from_file(str(in_file)) as tfile:
-        assert tfile.file_name == "infile.txt"
-    # check data
-    with TestFile.from_file(str(in_file), file_name="outfile.txt") as tfile:
-        assert tfile.file_name == "outfile.txt"
-        tfile.dump(str(tmp_path))
-        out_file = tmp_path / "outfile.txt"
-        assert out_file.is_file()
-        assert out_file.read_text() == "foobar"
-
-
-def test_testfile_07(tmp_path):
-    """test TestFile.clone()"""
-    out_file = tmp_path / "test_file.txt"
-    with TestFile(out_file.name) as tf1:
-        tf1.write(b"foobar")
-        try:
-            tf2 = tf1.clone()
-            tf2.write(b"test")
-            assert tf1.file_name == tf2.file_name
-            assert tf1._fp != tf2._fp
-            tf2.dump(str(tmp_path))
-            assert out_file.is_file()
-            assert out_file.read_text() == "foobartest"
-        finally:
-            tf2.close()
-        tf1.dump(str(tmp_path))
-        assert out_file.is_file()
-        assert out_file.read_text() == "foobar"
-
-
-def test_testfile_08(tmp_path):
-    """test TestFile.data()"""
-    in_file = tmp_path / "infile.txt"
-    in_file.write_bytes(b"foobar")
-    with TestFile.from_file(str(in_file), file_name="outfile.txt") as tfile:
-        assert tfile.data == b"foobar"
+@mark.parametrize(
+    "path, expected_result",
+    [
+        ("a", "a"),
+        ("file.bin", "file.bin"),
+        ("a/file.bin", "a/file.bin"),
+        ("/file.bin", "file.bin"),
+        ("./file.bin", "file.bin"),
+        ("path\\file", "path/file"),
+        ("\\\\a\\b\\file.bin", "a/b/file.bin"),
+        (".file", ".file"),
+        ("a/../file.bin", "file.bin"),
+        ("./a/./b/../c", "a/c"),
+    ],
+)
+def test_testfile_04(path, expected_result):
+    """test TestCase.sanitize_path()"""
+    assert TestFile.sanitize_path(path) == expected_result

--- a/grizzly/common/test_storage.py
+++ b/grizzly/common/test_storage.py
@@ -136,17 +136,17 @@ def test_testcase_06(tmp_path):
     """test TestCase.load_single() using a directory - fail cases"""
     # missing test_info.json
     with raises(TestCaseLoadFailure, match="Missing 'test_info.json'"):
-        TestCase.load_single(str(tmp_path))
+        TestCase.load_single(tmp_path)
     # invalid test_info.json
     (tmp_path / "test_info.json").write_bytes(b"X")
     with raises(TestCaseLoadFailure, match="Invalid 'test_info.json'"):
-        TestCase.load_single(str(tmp_path))
+        TestCase.load_single(tmp_path)
     # test_info.json missing 'target' entry
     (tmp_path / "test_info.json").write_bytes(b"{}")
     with raises(
         TestCaseLoadFailure, match="'test_info.json' has invalid 'target' entry"
     ):
-        TestCase.load_single(str(tmp_path))
+        TestCase.load_single(tmp_path)
     # build a test case
     src_dir = tmp_path / "src"
     src_dir.mkdir()
@@ -158,7 +158,7 @@ def test_testcase_06(tmp_path):
     # bad 'target' entry in test_info.json
     entry_point.unlink()
     with raises(TestCaseLoadFailure, match="Entry point 'target.bin' not found in"):
-        TestCase.load_single(str(src_dir))
+        TestCase.load_single(src_dir)
     # bad 'env' entry in test_info.json
     entry_point.touch()
     with AssetManager(base_path=str(tmp_path)) as assets:
@@ -171,7 +171,7 @@ def test_testcase_06(tmp_path):
     test_info["env"] = {"bad": 1}
     (src_dir / "test_info.json").write_text(dumps(test_info))
     with raises(TestCaseLoadFailure, match="'env' contains invalid entries"):
-        TestCase.load_single(str(src_dir))
+        TestCase.load_single(src_dir)
 
 
 def test_testcase_07(mocker, tmp_path):
@@ -206,7 +206,7 @@ def test_testcase_07(mocker, tmp_path):
             src.assets = assets
             src.dump(str(dst_dir), include_details=True)
     # test loading test case from test_info.json
-    with TestCase.load_single(str(dst_dir)) as dst:
+    with TestCase.load_single(dst_dir) as dst:
         asset = dst.pop_assets()
         assert asset
         with asset:
@@ -221,14 +221,14 @@ def test_testcase_07(mocker, tmp_path):
     # test load with missing asset
     mocker.patch("grizzly.common.storage.AssetManager.load", side_effect=OSError)
     with raises(TestCaseLoadFailure):
-        TestCase.load_single(str(dst_dir))
+        TestCase.load_single(dst_dir)
 
 
 def test_testcase_08(tmp_path):
     """test TestCase.load_single() using a file"""
     # invalid entry_point specified
     with raises(TestCaseLoadFailure, match="Missing or invalid TestCase"):
-        TestCase.load_single(str(tmp_path / "missing_file"), adjacent=False)
+        TestCase.load_single(tmp_path / "missing_file", adjacent=False)
     # valid test case
     src_dir = tmp_path / "src"
     src_dir.mkdir()
@@ -236,7 +236,7 @@ def test_testcase_08(tmp_path):
     entry_point.touch()
     (src_dir / "optional.bin").touch()
     # load single file test case
-    with TestCase.load_single(str(entry_point), adjacent=False) as tcase:
+    with TestCase.load_single(entry_point, adjacent=False) as tcase:
         assert tcase.assets is None
         assert not tcase.env_vars
         assert tcase.landing_page == "target.bin"
@@ -244,7 +244,7 @@ def test_testcase_08(tmp_path):
         assert "optional.bin" not in (x.file_name for x in tcase._files.optional)
         assert tcase.timestamp == 0
     # load full test case
-    with TestCase.load_single(str(entry_point), adjacent=True) as tcase:
+    with TestCase.load_single(entry_point, adjacent=True) as tcase:
         assert tcase.landing_page == "target.bin"
         assert "target.bin" in (x.file_name for x in tcase._files.required)
         assert "optional.bin" in (x.file_name for x in tcase._files.optional)
@@ -269,7 +269,7 @@ def test_testcase_09(tmp_path):
             org.assets = assets
             org.dump(str(working), include_details=True)
         org.assets = None
-        with TestCase.load_single(str(working), adjacent=False) as loaded:
+        with TestCase.load_single(working, adjacent=False) as loaded:
             try:
                 for prop in TestCase.__slots__:
                     if prop.startswith("_") or prop in ("assets", "redirect_page"):
@@ -424,17 +424,17 @@ def test_testcase_16(tmp_path):
     """test TestCase.scan_path()"""
     # empty path
     (tmp_path / "not-test").mkdir()
-    assert not any(TestCase.scan_path(str(tmp_path)))
+    assert not any(TestCase.scan_path(tmp_path))
     # multiple test case directories
-    paths = [str(tmp_path / ("test-%d" % i)) for i in range(3)]
+    paths = [tmp_path / ("test-%d" % i) for i in range(3)]
     with TestCase("test.htm", None, "test-adapter") as src:
         src.add_from_bytes(b"test", "test.htm")
         for path in paths:
-            src.dump(path, include_details=True)
-    tc_paths = list(TestCase.scan_path(str(tmp_path)))
+            src.dump(str(path), include_details=True)
+    tc_paths = list(TestCase.scan_path(tmp_path))
     assert len(tc_paths) == 3
     # single test case directory
-    tc_paths = list(TestCase.scan_path(str(paths[0])))
+    tc_paths = list(TestCase.scan_path(paths[0]))
     assert len(tc_paths) == 1
 
 

--- a/grizzly/common/test_storage.py
+++ b/grizzly/common/test_storage.py
@@ -483,20 +483,6 @@ def test_testcase_19():
             assert not set(src.optional) ^ set(dst.optional)
 
 
-def test_testcase_20(tmp_path):
-    """test TestCase.copy_file()"""
-    src_file = tmp_path / "src" / "file.txt"
-    src_file.parent.mkdir(parents=True)
-    src_file.write_bytes(b"test\n123\r\n")
-    dst_path = tmp_path / "dst"
-    dst_file = dst_path / "file.txt"
-    assert not dst_file.is_file()
-    TestCase.copy_file(src_file, dst_file)
-    assert dst_file.is_file()
-    assert dst_file.read_bytes() == b"test\n123\r\n"
-    assert src_file.exists()
-
-
 @mark.parametrize(
     "path",
     [
@@ -520,7 +506,7 @@ def test_testcase_20(tmp_path):
         ".",
     ],
 )
-def test_testcase_21(path):
+def test_testcase_20(path):
     """test TestCase.sanitize_path() with invalid paths"""
     with raises(ValueError, match="invalid path"):
         TestCase.sanitize_path(path)
@@ -541,6 +527,6 @@ def test_testcase_21(path):
         ("./a/./b/../c", "a/c"),
     ],
 )
-def test_testcase_22(path, expected_result):
+def test_testcase_21(path, expected_result):
     """test TestCase.sanitize_path()"""
     assert TestCase.sanitize_path(path) == expected_result

--- a/grizzly/common/test_storage.py
+++ b/grizzly/common/test_storage.py
@@ -113,7 +113,7 @@ def test_testcase_05():
         # no optional files
         tcase.purge_optional(["foo"])
         # setup
-        tcase.add_from_bytes(b"foo", "testfile1.bin")
+        tcase.add_from_bytes(b"foo", "testfile1.bin", required=True)
         tcase.add_from_bytes(b"foo", "testfile2.bin", required=False)
         tcase.add_from_bytes(b"foo", "testfile3.bin", required=False)
         tcase.add_from_bytes(b"foo", "not_served.bin", required=False)
@@ -461,7 +461,7 @@ def test_testcase_19():
     with TestCase("a.htm", "b.htm", "adpt", input_fname="fn", time_limit=2) as src:
         src.duration = 1.2
         src.hang = True
-        src.add_from_bytes(b"123", "test.htm")
+        src.add_from_bytes(b"123", "test.htm", required=True)
         src.add_from_bytes(b"456", "opt.htm", required=False)
         src.env_vars["foo"] = "bar"
         with src.clone() as dst:

--- a/grizzly/reduce/test_strategies_beautify.py
+++ b/grizzly/reduce/test_strategies_beautify.py
@@ -19,12 +19,12 @@ def _test_beautify(cls, interesting, test_name, test_data, reduced, mocker):
     mocker.patch("grizzly.reduce.strategies.beautify._contains_dd", return_value=True)
 
     best_test = TestCase(test_name, None, "test-adapter")
-    best_test.add_from_data(test_data, test_name)
+    best_test.add_from_bytes(test_data.encode("ascii"), test_name)
     best_tests = [best_test]
 
     def _interesting(testcases):
         for test in testcases:
-            contents = test.get_file(test_name).data.decode("ascii")
+            contents = test.get_file(test_name).data_file.read_bytes().decode("ascii")
             if interesting(contents):
                 return True
         return False
@@ -44,7 +44,9 @@ def _test_beautify(cls, interesting, test_name, test_data, reduced, mocker):
                     for test in tests:
                         test.cleanup()
         assert len(best_tests) == 1
-        contents = best_tests[0].get_file(test_name).data.decode("ascii")
+        contents = (
+            best_tests[0].get_file(test_name).data_file.read_bytes().decode("ascii")
+        )
         assert contents == reduced
     finally:
         for test in best_tests:

--- a/grizzly/replay/test_main.py
+++ b/grizzly/replay/test_main.py
@@ -47,7 +47,7 @@ def test_main_01(mocker, tmp_path):
     load_target.return_value.return_value = target
     with TestCase("test.html", None, "adpt") as src:
         src.env_vars["TEST_VAR"] = "100"
-        src.add_from_data("test", "test.html")
+        src.add_from_bytes(b"test", "test.html")
         src.dump(str(tmp_path / "testcase"), include_details=True)
     # setup args
     log_path = tmp_path / "logs"

--- a/grizzly/replay/test_replay.py
+++ b/grizzly/replay/test_replay.py
@@ -544,7 +544,6 @@ def test_replay_15(mocker):
         assert replay.status.iteration == 1
         assert replay.status.results.total == 0
     assert target.close.call_count == 2
-    assert all(x.dump.call_count == 1 for x in testcases)
 
 
 def test_replay_16(mocker):
@@ -569,7 +568,6 @@ def test_replay_16(mocker):
         assert replay.status.iteration == 10
         assert replay.status.results.total == 0
     assert target.monitor.is_healthy.call_count == 5
-    assert all(x.dump.call_count == 1 for x in testcases)
 
 
 def test_replay_17(mocker):
@@ -605,7 +603,6 @@ def test_replay_17(mocker):
     assert results[0].served[1][0] == "b.html"
     assert results[0].served[2][0] == "c.html"
     assert len(results[0].durations) == len(testcases)
-    assert all(x.dump.call_count == 1 for x in testcases)
 
 
 def test_replay_18(mocker):

--- a/grizzly/session.py
+++ b/grizzly/session.py
@@ -227,7 +227,7 @@ class Session:
             if not result.attempted:
                 LOG.warning("Test case was not served")
                 LOG.debug("ignoring test case since nothing was served")
-                if not current_test.contains(current_test.landing_page):
+                if current_test.landing_page not in current_test.contents:
                     raise SessionError("Test case is missing landing page")
                 if result.initial:
                     # since this is the first iteration since the Target launched

--- a/grizzly/test_session.py
+++ b/grizzly/test_session.py
@@ -35,7 +35,7 @@ class SimpleAdapter(Adapter):
     def generate(self, testcase, _server_map):
         assert testcase.adapter_name == self.name
         testcase.input_fname = self.fuzz["input"]
-        testcase.add_from_data("test", testcase.landing_page)
+        testcase.add_from_bytes(b"test", testcase.landing_page)
         if self.remaining is not None:
             assert self.remaining > 0
             self.remaining -= 1

--- a/sapphire/test_job.py
+++ b/sapphire/test_job.py
@@ -5,6 +5,7 @@ Job unit tests
 # pylint: disable=protected-access
 
 import platform
+from pathlib import Path
 
 import pytest
 
@@ -248,12 +249,14 @@ def test_job_09():
 
 
 def test_job_10(tmp_path):
-    """test Job.increment_served() and Job.served"""
+    """test Job.mark_served() and Job.served"""
     job = Job(str(tmp_path))
     assert not any(job.served)
-    job.increment_served(str(tmp_path / "file.bin"))
-    assert "file.bin" in job.served
-    job.increment_served("/some/include/path/inc.bin")
+    job.mark_served(tmp_path / "a.bin")
+    assert "a.bin" in job.served
+    job.mark_served(tmp_path / "nested" / "b.bin")
+    assert "nested/b.bin" in job.served
+    job.mark_served(Path("/some/include/path/inc.bin"))
     assert "/some/include/path/inc.bin" in job.served
 
 

--- a/sapphire/test_sapphire.py
+++ b/sapphire/test_sapphire.py
@@ -410,9 +410,9 @@ def test_sapphire_18(client, tmp_path):
         status, files_served = serv.serve_path(str(root_path), server_map=smap)
     assert status == Served.ALL
     assert "test_case.html" in files_served
-    assert str(inc1_path / "included_file1.html") in files_served
-    assert str(inc2_path / "included_file2.html") in files_served
-    assert str(nest_path / "nested_file.html") in files_served
+    assert (inc1_path / "included_file1.html").as_posix() in files_served
+    assert (inc2_path / "included_file2.html").as_posix() in files_served
+    assert (nest_path / "nested_file.html").as_posix() in files_served
     assert client.wait(timeout=10)
     assert inc1.code == 200
     assert inc2.code == 200

--- a/sapphire/worker.py
+++ b/sapphire/worker.py
@@ -8,6 +8,7 @@ Sapphire HTTP server worker
 from logging import getLogger
 from os import stat
 from os.path import isfile
+from pathlib import Path
 from re import compile as re_compile
 from socket import error as sock_error
 from socket import timeout as sock_timeout
@@ -199,7 +200,7 @@ class Worker:
                     conn.sendall(in_fp.read(cls.DEFAULT_TX_SIZE))
                     offset = in_fp.tell()
             LOG.debug("200 %r (%d to go)", resource.target, serv_job.pending)
-            serv_job.increment_served(resource.target)
+            serv_job.mark_served(Path(resource.target))
 
         except (sock_error, sock_timeout):
             _, exc_obj, exc_tb = exc_info()


### PR DESCRIPTION
- Write TestFile data to filesystem instead of caching (this allows us reduces the overall number of writes in many cases)
- Rename TestCase.add_from_data() to TestCase.add_from_bytes()
- Add 'copy' kwarg to TestCase.add_from_file()
- Add TestCase.data_path property for serving directly
- Replace TestCase.contains() with TestCase.contents property