### PR TITLE
[sapphire] Call socket.shutdown() when closing active workers

### DIFF
--- a/sapphire/connection_manager.py
+++ b/sapphire/connection_manager.py
@@ -95,6 +95,7 @@ class ConnectionManager:
     def listener(serv_sock, serv_job, max_workers, shutdown_delay=0):
         assert max_workers > 0
         assert shutdown_delay >= 0
+        total_launches = 0
         worker_pool = list()
         pool_size = 0
         LOG.debug("starting listener")
@@ -106,6 +107,7 @@ class ConnectionManager:
                 if worker is not None:
                     worker_pool.append(worker)
                     pool_size += 1
+                    total_launches += 1
                 # manage worker pool
                 if pool_size >= max_workers:
                     LOG.debug(
@@ -132,9 +134,10 @@ class ConnectionManager:
             serv_job.finish()
         finally:
             LOG.debug(
-                "shutting down listener, waiting %0.2fs for %d worker(s)...",
+                "shutting down listener, waiting %0.2fs for %d of %d worker(s)...",
                 shutdown_delay,
                 len(worker_pool),
+                total_launches,
             )
             # use shutdown_delay to avoid cutting off connections
             deadline = time() + shutdown_delay

--- a/sapphire/worker.py
+++ b/sapphire/worker.py
@@ -7,6 +7,7 @@ Sapphire HTTP server worker
 """
 from logging import getLogger
 from re import compile as re_compile
+from socket import SHUT_RDWR
 from socket import error as sock_error
 from socket import timeout as sock_timeout
 from sys import exc_info
@@ -80,6 +81,8 @@ class Worker:
     def close(self):
         if not self.done:
             LOG.debug("closing socket while thread is running!")
+            # shutdown socket to avoid hang
+            self._conn.shutdown(SHUT_RDWR)
         self._conn.close()
         self.join(timeout=60)
         if self._thread is not None and self._thread.is_alive():


### PR DESCRIPTION
This will avoid worker hangs when the browser hangs.