### PR TITLE
Update linters and drop Python 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/yesqa
@@ -8,20 +8,20 @@ repos:
     hooks:
       - id: yesqa
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: ['--py37-plus']
   - repo: https://github.com/ambv/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: ['--py37-plus']
+        args: ['--py38-plus']
   - repo: https://github.com/ambv/black
     rev: 22.12.0
     hooks:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -48,10 +48,6 @@ tasks:
         - tox; tox -e codecov
       jobs:
         include:
-          - name: tests python 3.7
-            version: "3.7"
-            env:
-              TOXENV: py37,lint
           - name: tests python 3.8
             version: "3.8"
             env:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages =
     grizzly.target
     loki
     sapphire
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311},lint
+envlist = py{38,39,310,311},lint
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 
 [testenv]
-commands = pytest -v --cache-clear --cov="{toxinidir}" --cov-config="{toxinidir}/pyproject.toml" --cov-report term-missing {posargs}
+commands = pytest -v --cache-clear --cov={toxinidir} --cov-config={toxinidir}/pyproject.toml --cov-report=term-missing {posargs}
 deps =
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ skip_install = true
 commands =
     pylint {posargs}
 deps =
-    pylint==2.15.3
+    pylint==2.15.10
 usedevelop = true
 
 [testenv:pypi]


### PR DESCRIPTION
This fixes #344.

isort and flake8 have dropped Python 3.7 support and that is causing issues, so let's do the same.