### PR TITLE
Add ignore_timeout kwarg to Target.handle_hang()

### DIFF
--- a/grizzly/common/runner.py
+++ b/grizzly/common/runner.py
@@ -298,7 +298,9 @@ class Runner:
             )
         if result.timeout:
             LOG.debug("timeout detected")
-            result.idle = self._target.handle_hang(ignore_idle=True)
+            result.idle = self._target.handle_hang(
+                ignore_idle=True, ignore_timeout="timeout" in ignore
+            )
             if result.idle or "timeout" in ignore:
                 result.status = Result.IGNORED
             server_map.dynamic.pop("grz_empty", None)

--- a/grizzly/target/target.py
+++ b/grizzly/target/target.py
@@ -123,7 +123,7 @@ class Target(metaclass=ABCMeta):
         return dict(self.environ)
 
     @abstractmethod
-    def handle_hang(self, ignore_idle=True):
+    def handle_hang(self, ignore_idle=True, ignore_timeout=False):
         pass
 
     # TODO: move to monitor?

--- a/grizzly/target/test_target.py
+++ b/grizzly/target/test_target.py
@@ -24,7 +24,7 @@ class SimpleTarget(Target):
     def create_report(self, is_hang=False):
         pass
 
-    def handle_hang(self, ignore_idle=True):
+    def handle_hang(self, ignore_idle=True, ignore_timeout=False):
         pass
 
     def launch(self, location):


### PR DESCRIPTION
This will avoid detecting crashes when forcing the browser to close when there is a timeout.