### PR TITLE
Always submit initial results

### DIFF
--- a/grizzly/common/test_reporter.py
+++ b/grizzly/common/test_reporter.py
@@ -47,7 +47,7 @@ def test_reporter_01(mocker, tmp_path, display_logs, is_hang):
         def _post_submit(self):
             pass
 
-        def _submit_report(self, report, test_cases):
+        def _submit_report(self, report, test_cases, force):
             pass
 
     (tmp_path / "log_stderr.txt").write_bytes(b"log msg")
@@ -208,8 +208,9 @@ def test_fuzzmanager_reporter_02(
     if tests:
         test_cases.append(fake_test)
     reporter = FuzzManagerReporter("fake-tool")
-    reporter.force_report = force
-    reporter.submit(test_cases, Report(log_path, Path("bin"), is_hang=True))
+    reporter.submit(
+        test_cases, Report(log_path, Path("bin"), is_hang=True), force=force
+    )
     assert not log_path.is_dir()
     assert fake_collector.call_args == ({"tool": "fake-tool"},)
     if (frequent and not force) or ignored:

--- a/grizzly/common/test_status.py
+++ b/grizzly/common/test_status.py
@@ -576,7 +576,7 @@ def test_report_counter_01(tmp_path, keys, counts, limit):
         assert not counter.is_frequent(report_id)
         # call count() with report_id 'counted' times
         for current in range(1, counted + 1):
-            assert counter.count(report_id, "desc") == current
+            assert counter.count(report_id, "desc") == (current, (current == 1))
         # test get()
         if sum(counts) > 0:
             assert counter.get(report_id) == (report_id, counted, "desc")
@@ -610,31 +610,31 @@ def test_report_counter_02(mocker, tmp_path):
     assert not counter_b.is_frequent("a")
     assert not counter_c.is_frequent("a")
     # local (counter_a, bucket a) count is 1, global (all counters) count is 1
-    assert counter_a.count("a", "desc") == 1
+    assert counter_a.count("a", "desc") == (1, True)
     assert not counter_a.is_frequent("a")
     assert not counter_b.is_frequent("a")
     assert not counter_c.is_frequent("a")
     # local (counter_b, bucket a) count is 1, global (all counters) count is 2
-    assert counter_b.count("a", "desc") == 1
+    assert counter_b.count("a", "desc") == (1, False)
     assert not counter_a.is_frequent("a")
     assert not counter_b.is_frequent("a")
     assert not counter_c.is_frequent("a")
     # local (counter_b, bucket a) count is 2, global (all counters) count is 3
     # locally exceeded
-    assert counter_b.count("a", "desc") == 2
+    assert counter_b.count("a", "desc") == (2, False)
     assert counter_b.is_frequent("a")
     # local (counter_c, bucket a) count is 1, global (all counters) count is 4
-    assert counter_c.count("a", "desc") == 1
+    assert counter_c.count("a", "desc") == (1, False)
     assert not counter_a.is_frequent("a")
     assert counter_b.is_frequent("a")
     assert not counter_c.is_frequent("a")
     # local (counter_a, bucket a) count is 2, global (all counters) count is 5
     # no limit
-    assert counter_a.count("a", "desc") == 2
+    assert counter_a.count("a", "desc") == (2, False)
     assert not counter_a.is_frequent("a")
     # local (counter_c, bucket a) count is 2, global (all counters) count is 6
     # locally not exceeded, globally exceeded
-    assert counter_c.count("a", "desc") == 2
+    assert counter_c.count("a", "desc") == (2, False)
     assert counter_c.is_frequent("a")
     # local (counter_a, bucket x) count is 0, global (all counters) count is 0
     assert not counter_a.is_frequent("x")

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -721,8 +721,6 @@ class ReduceManager:
         for result in results:
             if self._report_to_fuzzmanager:
                 reporter = FuzzManagerReporter(self._report_tool)
-                if result.expected:
-                    reporter.force_report = True
             else:
                 report_dir = "reports" if result.expected else "other_reports"
                 reporter = FilesystemReporter(
@@ -742,7 +740,7 @@ class ReduceManager:
                 if result.served is not None:
                     for clone, served in zip(clones, result.served):
                         clone.purge_optional(served)
-                result = reporter.submit(clones, result.report)
+                result = reporter.submit(clones, result.report, force=result.expected)
                 if result is not None:
                     if isinstance(result, Path):
                         result = str(result)

--- a/grizzly/reduce/test_reduce.py
+++ b/grizzly/reduce/test_reduce.py
@@ -843,7 +843,8 @@ def test_include_assets_and_environ(mocker, tmp_path):
 
     reporter = mocker.patch("grizzly.reduce.core.FilesystemReporter", autospec=True)
 
-    def submit(test_cases, report):
+    # pylint: disable=unused-argument
+    def submit(test_cases, report, force=False):
         assert test_cases
         assert isinstance(report, Report)
         for test in test_cases:

--- a/grizzly/replay/replay.py
+++ b/grizzly/replay/replay.py
@@ -246,8 +246,7 @@ class ReplayManager:
         for result in results:
             # always report expected results
             # avoid reporting unexpected frequent results
-            reporter.force_report = result.expected
-            reporter.submit(tests, result.report)
+            reporter.submit(tests, result.report, force=result.expected)
 
     def run(
         self,

--- a/grizzly/session.py
+++ b/grizzly/session.py
@@ -258,7 +258,7 @@ class Session:
                     else:
                         # FM crash signature creation failed
                         short_sig = "Signature creation failed"
-                seen = self.status.results.count(bucket_hash, short_sig)
+                seen, initial = self.status.results.count(bucket_hash, short_sig)
                 LOG.info(
                     "Result: %s (%s:%s) - %d",
                     short_sig,
@@ -266,8 +266,8 @@ class Session:
                     report.minor[:8],
                     seen,
                 )
-                if not self.status.results.is_frequent(bucket_hash):
-                    self.reporter.submit(self.iomanager.tests, report)
+                if initial or not self.status.results.is_frequent(bucket_hash):
+                    self.reporter.submit(self.iomanager.tests, report, force=initial)
                 else:
                     # we should always submit the first instance of a result
                     assert seen > 1


### PR DESCRIPTION
When a result is detected for the first time it is always submitted. This can be blocked by the FuzzManager frequent flag. The submission is forced if the result has only been found once (including parallel instances). For subsequent submissions we check if the result is frequent and report accordingly. This takes into account results found by parallel instances.