### PR TITLE
Handle target hangs immediately after launch

### DIFF
--- a/grizzly/common/bugzilla.py
+++ b/grizzly/common/bugzilla.py
@@ -18,6 +18,7 @@ from .utils import grz_tmp
 
 # attachments that can be ignored
 IGNORE_EXTS = frozenset({"c", "cpp", "diff", "exe", "log", "patch", "php", "py", "txt"})
+# TODO: support all target assets
 KNOWN_ASSETS = {"prefs": "prefs.js"}
 LOG = getLogger(__name__)
 

--- a/grizzly/common/test_runner.py
+++ b/grizzly/common/test_runner.py
@@ -394,6 +394,8 @@ def test_runner_11(mocker):
         (-1, None, False),
         # startup failure
         (0, (Served.NONE, None), True),
+        # target hang while loading content
+        (0, (Served.TIMEOUT, None), True),
     ],
 )
 def test_runner_12(mocker, delay, srv_result, startup_failure):


### PR DESCRIPTION
This should fix the hangs seen when running flaky ccov builds.