### PR TITLE
[sapphire] Improved stability handling invalid URLs

### DIFF
--- a/sapphire/test_worker.py
+++ b/sapphire/test_worker.py
@@ -4,6 +4,7 @@ Sapphire unit tests
 # pylint: disable=protected-access
 
 import socket
+from random import randint
 from threading import Thread, ThreadError
 
 from pytest import mark
@@ -196,11 +197,22 @@ def test_response_01(req, method, scheme, path):
     "req",
     [
         b"a",
+        # Invalid IPv6 URL
         b"GET http://[test/ HTTP/1.1",
         b"GET  HTTP/1.1",
         b"GET a a a a a HTTP/1.1",
+        # Invalid characters under NFKC normalization
+        b"GET http://%E2%84%80/ HTTP/1.1",
     ],
 )
 def test_response_02(req):
     """test Request.parse() failures"""
     assert Request.parse(req) is None
+
+
+def test_response_03():
+    """test Request.parse() by passing random urls"""
+    for _ in range(1000):
+        # create random 'netloc', for example '%1A%EF%09'
+        chars = "".join([f"%{randint(0, 255):02X}" for _ in range(randint(1, 8))])
+        Request.parse(f"GET http://{chars}/ HTTP/1.1".encode())

--- a/sapphire/worker.py
+++ b/sapphire/worker.py
@@ -47,12 +47,16 @@ class Request:
         # TODO: parse headers if needed
 
         try:
+            url_str = req_match.group("url").decode("ascii", errors="replace")
             # unquote() accepts str | bytes as of Python 3.9
-            url = urlparse(
-                unquote(req_match.group("url").decode("ascii", errors="replace"))
-            )
+            url = urlparse(unquote(url_str))
         except ValueError as exc:
-            if "Invalid IPv6 URL" not in str(exc):  # pragma: no cover
+            msg = str(exc)
+            if (
+                "contains invalid characters under NFKC normalization" not in msg
+                and "Invalid IPv6 URL" not in msg
+            ):
+                LOG.error("Failed to parse URL: %r", url_str)
                 raise
             LOG.debug("failed to parse url from request")
             return None


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/home/worker/grizzly-auto-run/venv/lib/python3.10/site-packages/sapphire/worker.py", line 146, in handle_request
    request = Request.parse(raw_request)
  File "/home/worker/grizzly-auto-run/venv/lib/python3.10/site-packages/sapphire/worker.py", line 51, in parse
    url = urlparse(
  File "/usr/lib/python3.10/urllib/parse.py", line 400, in urlparse
    splitresult = urlsplit(url, scheme, allow_fragments)
  File "/usr/lib/python3.10/urllib/parse.py", line 500, in urlsplit
    _checknetloc(netloc)
  File "/usr/lib/python3.10/urllib/parse.py", line 441, in _checknetloc
    raise ValueError("netloc '" + netloc + "' contains invalid " +
ValueError: netloc '⁡<<=)𤱍᩿ﷺ٠𯄬Ⱥ㮺^=𖔠𯊖𯚇^=𯓚*=𐎭᷌ 󠳀ك%𝟯ᾂ٪℀�0𧸄ູ𯨾｠𯹕㔮𝅱‫𝬍𣥫%=𝋼&`𐇽𛒀𓪂٠𨕁゚R𯄎٪߫孁' contains invalid characters under NFKC normalization
```