### PR TITLE
Record GPU usage environment variable

### DIFF
--- a/grizzly/common/reporter.py
+++ b/grizzly/common/reporter.py
@@ -271,9 +271,8 @@ class FuzzManagerReporter(Reporter):
             quality = Quality.UNREDUCED
             if test_cases[0].env_vars:
                 # add environment variables to metadata
-                self.add_extra_metadata(
-                    "recorded_envvars",
-                    " ".join("=".join(kv) for kv in test_cases[0].env_vars.items()),
+                report.crash_info.configuration.addEnvironmentVariables(
+                    test_cases[0].env_vars
                 )
         else:
             quality = Quality.NO_TESTCASE

--- a/grizzly/target/puppet_target.py
+++ b/grizzly/target/puppet_target.py
@@ -90,6 +90,7 @@ class PuppetTarget(Target):
         "GNOME_ACCESSIBILITY",
         "MOZ_CHAOSMODE",
         "MOZ_FUZZ_CRASH_ON_LARGE_ALLOC",
+        "MOZ_FUZZ_HAS_GPU",
         "MOZ_FUZZ_LARGE_ALLOC_LIMIT",
         "XPCOM_DEBUG_BREAK",
     )


### PR DESCRIPTION
Also use the `env` field in FuzzManager rather than adding a new one to metadata.