### PR TITLE
Replace use of pkg_resources with importlib.metadata

### DIFF
--- a/grizzly/args.py
+++ b/grizzly/args.py
@@ -18,8 +18,7 @@ from typing import Iterable, List, Optional
 from FTB.ProgramConfiguration import ProgramConfiguration
 
 from .common.fuzzmanager import FM_CONFIG
-from .common.plugins import scan as scan_plugins
-from .common.plugins import scan_target_assets
+from .common.plugins import scan_plugins, scan_target_assets
 from .common.utils import DEFAULT_TIME_LIMIT, TIMEOUT_DELAY, package_version
 
 

--- a/grizzly/common/test_plugins.py
+++ b/grizzly/common/test_plugins.py
@@ -1,11 +1,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from pkg_resources import EntryPoint
+from importlib.metadata import EntryPoint
+
 from pytest import raises
 
 from ..target import Target
-from .plugins import PluginLoadError, load, scan, scan_target_assets
+from .plugins import PluginLoadError, load_plugin, scan_plugins, scan_target_assets
 
 
 class FakeType1:
@@ -19,22 +20,23 @@ class FakeType2:
 def test_load_01(mocker):
     """test load() - nothing to load"""
     mocker.patch(
-        "grizzly.common.plugins.iter_entry_points", autospec=True, return_value=[]
+        "grizzly.common.plugins.iter_entry_points", autospec=True, return_value=()
     )
     with raises(PluginLoadError, match="'test-name' not found in 'test-group'"):
-        load("test-name", "test-group", FakeType1)
+        load_plugin("test-name", "test-group", FakeType1)
 
 
 def test_load_02(mocker):
     """test load() - successful load"""
-    # Note: Mock.name cannot be set via the constructor so spec_set cannot be used
     entry = mocker.Mock(spec=EntryPoint)
     entry.name = "test-name"
     entry.load.return_value = FakeType1
     mocker.patch(
-        "grizzly.common.plugins.iter_entry_points", autospec=True, return_value=[entry]
+        "grizzly.common.plugins.iter_entry_points",
+        autospec=True,
+        return_value=(entry,),
     )
-    assert load("test-name", "test-group", FakeType1)
+    assert load_plugin("test-name", "test-group", FakeType1)
 
 
 def test_load_03(mocker):
@@ -43,18 +45,20 @@ def test_load_03(mocker):
     entry.name = "test-name"
     entry.load.return_value = FakeType1
     mocker.patch(
-        "grizzly.common.plugins.iter_entry_points", autospec=True, return_value=[entry]
+        "grizzly.common.plugins.iter_entry_points",
+        autospec=True,
+        return_value=(entry,),
     )
     with raises(PluginLoadError, match="'test-name' doesn't inherit from FakeType2"):
-        load("test-name", "test-group", FakeType2)
+        load_plugin("test-name", "test-group", FakeType2)
 
 
 def test_scan_01(mocker):
     """test scan() - no entries found"""
     mocker.patch(
-        "grizzly.common.plugins.iter_entry_points", autospec=True, return_value=[]
+        "grizzly.common.plugins.iter_entry_points", autospec=True, return_value=()
     )
-    assert not scan("test_group")
+    assert not scan_plugins("test_group")
 
 
 def test_scan_02(mocker):
@@ -64,10 +68,10 @@ def test_scan_02(mocker):
     mocker.patch(
         "grizzly.common.plugins.iter_entry_points",
         autospec=True,
-        return_value=[entry, entry],
+        return_value=(entry, entry),
     )
     with raises(PluginLoadError, match="Duplicate entry 'test_entry' in 'test_group'"):
-        scan("test_group")
+        scan_plugins("test_group")
 
 
 def test_scan_03(mocker):
@@ -77,26 +81,26 @@ def test_scan_03(mocker):
     mocker.patch(
         "grizzly.common.plugins.iter_entry_points",
         autospec=True,
-        return_value=[entry],
+        return_value=(entry,),
     )
-    assert "test-name" in scan("test_group")
+    assert "test-name" in scan_plugins("test_group")
 
 
 def test_scan_target_assets_01(mocker):
     """test scan_target_assets() - success"""
     targ1 = mocker.Mock(spec=EntryPoint)
     targ1.name = "t1"
-    targ1.load.return_value = mocker.Mock(spec_set=Target, SUPPORTED_ASSETS=None)
+    targ1.load.return_value = mocker.Mock(spec_set=Target, SUPPORTED_ASSETS=())
     targ2 = mocker.Mock(spec=EntryPoint)
     targ2.name = "t2"
     targ2.load.return_value = mocker.Mock(spec_set=Target, SUPPORTED_ASSETS=("a", "B"))
     mocker.patch(
         "grizzly.common.plugins.iter_entry_points",
         autospec=True,
-        return_value=[targ1, targ2],
+        return_value=(targ1, targ2),
     )
     assets = scan_target_assets()
     assert "t1" in assets
-    assert assets["t1"] is None
+    assert not assets["t1"]
     assert "t2" in assets
     assert "B" in assets["t2"]

--- a/grizzly/common/utils.py
+++ b/grizzly/common/utils.py
@@ -1,13 +1,14 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import sys  # mypy looks for `sys.version_info`
 from enum import IntEnum, unique
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import EntryPoint, PackageNotFoundError, entry_points, version
 from logging import DEBUG, basicConfig, getLogger
 from os import getenv
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Generator, Iterable, Optional, Tuple, Union
 
 __all__ = (
     "ConfigError",
@@ -17,6 +18,7 @@ __all__ = (
     "Exit",
     "grz_tmp",
     "HARNESS_FILE",
+    "iter_entry_points",
     "package_version",
     "time_limits",
     "TIMEOUT_DELAY",
@@ -103,6 +105,25 @@ def display_time_limits(time_limit: int, timeout: int, no_harness: bool) -> None
         else:
             LOG.info("Using time limit: %ds, timeout: DISABLED,", time_limit)
         LOG.warning("TIMEOUT DISABLED, not recommended for automation")
+
+
+def iter_entry_points(
+    group: str,
+) -> Generator[EntryPoint, None, None]:  # pragma: no cover
+    """Compatibility wrapper code for importlib.metadata.entry_points()
+
+    Args:
+        group: See entry_points().
+
+    Yields:
+        EntryPoint
+    """
+    # TODO: remove this function when support for Python 3.9 is dropped
+    assert group
+    if sys.version_info >= (3, 10):
+        yield from entry_points().select(group=group)
+    else:
+        raise AssertionError("Unsupported Python version")
 
 
 def package_version(name: str, default: str = "unknown") -> str:

--- a/grizzly/main.py
+++ b/grizzly/main.py
@@ -9,7 +9,7 @@ from typing import Optional, cast
 from sapphire import CertificateBundle, Sapphire
 
 from .adapter import Adapter
-from .common.plugins import load as load_plugin
+from .common.plugins import load_plugin
 from .common.reporter import (
     FailedLaunchReporter,
     FilesystemReporter,

--- a/grizzly/reduce/core.py
+++ b/grizzly/reduce/core.py
@@ -18,7 +18,7 @@ from FTB.Signatures.CrashInfo import CrashSignature
 from sapphire import CertificateBundle, Sapphire
 
 from ..common.fuzzmanager import CrashEntry
-from ..common.plugins import load as load_plugin
+from ..common.plugins import load_plugin
 from ..common.reporter import (
     FailedLaunchReporter,
     FilesystemReporter,

--- a/grizzly/reduce/strategies/__init__.py
+++ b/grizzly/reduce/strategies/__init__.py
@@ -30,10 +30,13 @@ from typing import (
     cast,
 )
 
-from pkg_resources import iter_entry_points
-
 from ...common.storage import TestCase
 from ...common.utils import grz_tmp
+
+try:
+    from pkg_resources import iter_entry_points
+except ImportError:
+    from ...common.utils import iter_entry_points  # type: ignore
 
 LOG = getLogger(__name__)
 

--- a/grizzly/reduce/test_strategies.py
+++ b/grizzly/reduce/test_strategies.py
@@ -82,11 +82,10 @@ def test_strategy_load_fail(mocker):
         def load(cls):
             raise RuntimeError("oops")
 
-    def entries(_):
-        yield _BadStrategy
-        yield _GoodStrategy
-
-    mocker.patch("grizzly.reduce.strategies.iter_entry_points", side_effect=entries)
+    mocker.patch(
+        "grizzly.reduce.strategies.iter_entry_points",
+        return_value=(_BadStrategy, _GoodStrategy),
+    )
     mocker.patch("grizzly.reduce.strategies.DEFAULT_STRATEGIES", new=("good",))
     result = _load_strategies()
     assert result == {"good": _GoodStrategy}

--- a/grizzly/replay/replay.py
+++ b/grizzly/replay/replay.py
@@ -13,7 +13,7 @@ from FTB.Signatures.CrashInfo import CrashSignature
 
 from sapphire import CertificateBundle, Sapphire, ServerMap
 
-from ..common.plugins import load as load_plugin
+from ..common.plugins import load_plugin
 from ..common.report import Report
 from ..common.reporter import (
     FailedLaunchReporter,


### PR DESCRIPTION
Use iter_entry_points() workaround until Python 3.9 support is dropped