### PR TITLE
feat: extend BugzillaBug

### DIFF
--- a/grizzly/common/test_bugzilla.py
+++ b/grizzly/common/test_bugzilla.py
@@ -49,9 +49,9 @@ def test_bugzilla_01(mocker):
         ),
     )
     with BugzillaBug(bug) as bz_bug:
-        assert len(tuple(bz_bug._data.iterdir())) == 1
-        assert (bz_bug._data / "test.html").is_file()
-        assert (bz_bug._data / "test.html").read_text() == "foo"
+        assert len(tuple(bz_bug.path.iterdir())) == 1
+        assert (bz_bug.path / "test.html").is_file()
+        assert (bz_bug.path / "test.html").read_text() == "foo"
 
 
 @mark.parametrize(


### PR DESCRIPTION
Update ignore list.
Make ignore list an optional parameter to BugzillaBug. Ignore attachments with missing extensions by default. Check before deleting data path.
Add BugzillaBug.path.