### PR TITLE
Block service start until started or raise

### DIFF
--- a/src/grizzly/services/base.py
+++ b/src/grizzly/services/base.py
@@ -26,5 +26,9 @@ class BaseService(ABC):
         """Wait until the service is ready"""
 
     @abstractmethod
+    def start(self, timeout: int) -> None:
+        """Start the service"""
+
+    @abstractmethod
     def cleanup(self) -> None:
         """Stop the server."""

--- a/src/grizzly/services/base.py
+++ b/src/grizzly/services/base.py
@@ -19,7 +19,7 @@ class BaseService(ABC):
 
     @abstractmethod
     def url(self, _query: str) -> bytes:
-        """Returns the URL of the server."""
+        """Returns the URL of the server"""
 
     @abstractmethod
     async def is_ready(self) -> None:
@@ -31,4 +31,4 @@ class BaseService(ABC):
 
     @abstractmethod
     def cleanup(self) -> None:
-        """Stop the server."""
+        """Stop the server"""

--- a/src/grizzly/services/webtransport/core.py
+++ b/src/grizzly/services/webtransport/core.py
@@ -35,12 +35,12 @@ LOG = getLogger(__name__)
 
 class WebTransportServer(BaseService):
     def __init__(self, port: int, cert: Path, key: Path) -> None:
-        """A WebTransport service.
+        """A WebTransport service
 
         Args:
-            port: The port on which to listen on.
-            cert: Certificate file.
-            key: Certificate's private key.
+            port: The port on which to listen on
+            cert: Certificate file
+            key: Certificate's private key
         """
         self._port = port
         self._cert = cert

--- a/src/grizzly/services/webtransport/test_webtransport.py
+++ b/src/grizzly/services/webtransport/test_webtransport.py
@@ -18,20 +18,14 @@ def test_webtransport_01():
     try:
         port = WebServices.get_free_port()
         web_transport = WebTransportServer(port, cert.host, cert.key)
-        assert not web_transport._started
-
         web_transport.start()
 
-        # Check that all services are running
-        assert web_transport._started
-        asyncio.run(asyncio.wait_for(web_transport.is_ready(), timeout=3.0))
+        asyncio.run(asyncio.wait_for(web_transport.is_ready(), timeout=1.0))
 
         assert web_transport.location == "grz_webtransport_server"
         assert isinstance(web_transport.url(""), bytes)
 
         web_transport.cleanup()
-
-        assert not web_transport._started
         with raises(asyncio.TimeoutError):
             asyncio.run(asyncio.wait_for(web_transport.is_ready(), timeout=1.0))
     finally:


### PR DESCRIPTION
In order to avoid a race between starting the Web Transport service and checking if it is active (both of which use the same event loop), I replaced the boolean flag with a threading Event.

See https://github.com/MozillaSecurity/grizzly/issues/489