### PR TITLE
Use worker to poll testcase tab

### DIFF
--- a/src/grizzly/common/harness.html
+++ b/src/grizzly/common/harness.html
@@ -45,7 +45,7 @@
           self.postMessage({type: 'poll'});
         }, 50);
       } else if (e.data.command === 'stop') {
-        if (pollInterval) {
+        if (pollInterval !== null) {
           clearInterval(pollInterval);
           pollInterval = null;
         }


### PR DESCRIPTION
Certain browser level exceptions can interrupt `setTimeout` causing the harness to hang.  As workers run in a separate thread, we can use them to monitor tab closures without interruption.